### PR TITLE
Navigation arrows on/off option

### DIFF
--- a/_inc/systemviews/simple.xml
+++ b/_inc/systemviews/simple.xml
@@ -43,40 +43,7 @@
 				<animation property="scale" from="1.05" to="1" begin="1300" duration="1000" mode="easeOut"/>
 			</storyboard>
 		</image>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 	</view>
+	<!-- Navigation arrows, if enabled -->
+  <include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/systemviews/vertical_anim.xml
+++ b/_inc/systemviews/vertical_anim.xml
@@ -19,56 +19,23 @@
 		</carousel>
 		<image name="logo">
 		<linearSmooth>true</linearSmooth>
-<storyboard event="activate">
-<animation property="x" to="0.5" begin="2500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="scroll">
-<animation property="x" to="0.5" begin="1500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="deactivate">
-<animation property="x" to="0.5" begin="1500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-		</image>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
+			<storyboard event="activate">
+				<animation property="x" to="0.5" begin="2500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
 			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
+			<storyboard event="scroll">
+				<animation property="x" to="0.5" begin="1500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
 			</storyboard>
-			<origin>0.5 0.5</origin>
+			<storyboard event="deactivate">
+				<animation property="x" to="0.5" begin="1500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
+			</storyboard>
 		</image>
 	</view>
+	<!-- Navigation arrows, if enabled -->
+  <include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/systemviews/vertical_left_anim.xml
+++ b/_inc/systemviews/vertical_left_anim.xml
@@ -19,56 +19,23 @@
 		</carousel>
 		<image name="logo">
 		<linearSmooth>true</linearSmooth>
-<storyboard event="activate">
-<animation property="x" to="-0.5" begin="2500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="scroll">
-<animation property="x" to="-0.5" begin="1500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="deactivate">
-<animation property="x" to="-0.5" begin="1500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-		</image>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
+			<storyboard event="activate">
+				<animation property="x" to="-0.5" begin="2500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
 			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
+			<storyboard event="scroll">
+				<animation property="x" to="-0.5" begin="1500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
 			</storyboard>
-			<origin>0.5 0.5</origin>
+			<storyboard event="deactivate">
+				<animation property="x" to="-0.5" begin="1500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
+			</storyboard>
 		</image>
 	</view>
+	<!-- Navigation arrows, if enabled -->
+  <include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/systemviews/wheel_anim.xml
+++ b/_inc/systemviews/wheel_anim.xml
@@ -19,56 +19,23 @@
 		</carousel>
 		<image name="logo">
 		<linearSmooth>true</linearSmooth>
-<storyboard event="activate">
-<animation property="x" to="0.5" begin="2500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="scroll">
-<animation property="x" to="0.5" begin="1500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="deactivate">
-<animation property="x" to="0.5" begin="1500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-		</image>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
+			<storyboard event="activate">
+				<animation property="x" to="0.5" begin="2500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
 			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
+			<storyboard event="scroll">
+				<animation property="x" to="0.5" begin="1500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
 			</storyboard>
-			<origin>0.5 0.5</origin>
+			<storyboard event="deactivate">
+				<animation property="x" to="0.5" begin="1500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
+			</storyboard>
 		</image>
 	</view>
+	<!-- Navigation arrows, if enabled -->
+  <include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/systemviews/wheel_left_anim.xml
+++ b/_inc/systemviews/wheel_left_anim.xml
@@ -20,56 +20,23 @@
 
 		<image name="logo">
 		<linearSmooth>true</linearSmooth>
-<storyboard event="activate">
-<animation property="x" to="-0.5" begin="2500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="scroll">
-<animation property="x" to="-0.5" begin="1500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="deactivate">
-<animation property="x" to="-0.5" begin="1500" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-		</image>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
+			<storyboard event="activate">
+				<animation property="x" to="-0.5" begin="2500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
 			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
+			<storyboard event="scroll">
+				<animation property="x" to="-0.5" begin="1500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
 			</storyboard>
-			<origin>0.5 0.5</origin>
+			<storyboard event="deactivate">
+				<animation property="x" to="-0.5" begin="1500" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
+			</storyboard>
 		</image>
 	</view>
+	<!-- Navigation arrows, if enabled -->
+  <include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Colorful (horizontally).xml
+++ b/_inc/views/Colorful (horizontally).xml
@@ -21,42 +21,6 @@
 			<zIndex>90</zIndex>
 		</image>
 
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-
 		<image name="md_thumbnail">
 			<origin>0.5 1</origin>
 			<pos>0.15 0.94</pos>
@@ -323,8 +287,6 @@
 			<zIndex>150</zIndex>
 		</image>
 		
-		
-		
 		<imagegrid name="gamegrid">
 			<pos>0.75 0.0</pos>
 			<size>0.25 1</size>
@@ -369,4 +331,6 @@
 			<animateColorTime>0</animateColorTime>
 		</ninepatch>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Colorful (vertically).xml
+++ b/_inc/views/Colorful (vertically).xml
@@ -20,42 +20,6 @@
 			<zIndex>90</zIndex>
 		</image>
 
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-
 		<image name="md_thumbnail">
 			<origin>1 0.5</origin>
 			<pos>0.64 0.5</pos>
@@ -378,4 +342,6 @@
 			<animateColorTime>0</animateColorTime>
 		</ninepatch>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Colorful + Gamelist (horizontally).xml
+++ b/_inc/views/Colorful + Gamelist (horizontally).xml
@@ -61,43 +61,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>90</zIndex>
 		</image>
-
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-
+  		
 		<image name="md_thumbnail">
 			<origin>0.5 1</origin>
 			<pos>0.15 0.94</pos>
@@ -373,4 +337,6 @@
 			<zIndex>150</zIndex>
 		</image>-->
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Colorful + Gamelist (vertically).xml
+++ b/_inc/views/Colorful + Gamelist (vertically).xml
@@ -73,42 +73,6 @@
 			<zIndex>90</zIndex>
 		</image>
 
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-
 		<image name="md_thumbnail">
 			<origin>1 0.5</origin>
 			<pos>0.64 0.5</pos>
@@ -374,4 +338,6 @@
 			<zIndex>150</zIndex>
 		</image>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Colorful + Wheel Left (horizontally).xml
+++ b/_inc/views/Colorful + Wheel Left (horizontally).xml
@@ -81,42 +81,6 @@
 			<zIndex>90</zIndex>
 		</image>
 
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-
 		<image name="md_thumbnail">
 			<origin>0.5 1</origin>
 			<pos>0.15 0.94</pos>
@@ -377,4 +341,6 @@
 			<zIndex>150</zIndex>
 		</image>
 </customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Colorful + Wheel Left (vertically).xml
+++ b/_inc/views/Colorful + Wheel Left (vertically).xml
@@ -81,42 +81,6 @@
 			<zIndex>90</zIndex>
 		</image>
 
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-
 		<image name="md_thumbnail">
 			<origin>1 0.5</origin>
 			<pos>0.64 0.5</pos>
@@ -383,4 +347,6 @@
 			<zIndex>150</zIndex>
 		</image>
 </customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Colorful + Wheel Right (horizontally).xml
+++ b/_inc/views/Colorful + Wheel Right (horizontally).xml
@@ -81,42 +81,6 @@
 			<zIndex>90</zIndex>
 		</image>
 
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-
 		<image name="md_thumbnail">
 			<origin>0.5 1</origin>
 			<pos>0.15 0.94</pos>
@@ -376,6 +340,7 @@
 			<origin>0.5 0.5</origin>
 			<zIndex>150</zIndex>
 		</image>
-		
 </customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Colorful + Wheel Right (vertically).xml
+++ b/_inc/views/Colorful + Wheel Right (vertically).xml
@@ -82,42 +82,6 @@
 			<zIndex>90</zIndex>
 		</image>
 
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-
 		<image name="md_thumbnail">
 			<origin>1 0.5</origin>
 			<pos>0.64 0.5</pos>
@@ -384,4 +348,6 @@
 			<zIndex>150</zIndex>
 		</image>
 </customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Detailed Dark.xml
+++ b/_inc/views/Detailed Dark.xml
@@ -19,41 +19,7 @@
 			<fontPath>./../../_inc/fonts/ubuntu_condensed.ttf</fontPath>
 			<fontSize>0.0194444444444444</fontSize>
 		</datetime>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
+
 		<video name="md_video">
 			<pos>0.540625 0.480555555555556</pos>
 			<maxSize>0.30 0.3833333333333333</maxSize>
@@ -343,4 +309,6 @@
 			<zIndex>150</zIndex>
 		</image>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Detailed No Video.xml
+++ b/_inc/views/Detailed No Video.xml
@@ -4,41 +4,6 @@
 <formatVersion>7</formatVersion>
 <!-- Подробно без видео -->
 	<customView name="Detailed No Video" inherits="detailed" displayName="${NoVideoDetailsViewName}">
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<video name="md_video">
 			<pos>1 1</pos>
 			<size>0 0</size>
@@ -124,4 +89,6 @@
 			<pos>0.551 0.222</pos>
 		</image>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/DetailedWheel.xml
+++ b/_inc/views/DetailedWheel.xml
@@ -4,43 +4,10 @@
 <formatVersion>7</formatVersion>
 <!-- Подробно + Колесо -->
 	<customView name="DetailedWheel" inherits="gamecarousel" displayName="${DetailedWheelName}">
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.745 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.735 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.756 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<gamecarousel name="gamecarousel">
 			<type>vertical</type>
 		</gamecarousel>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/VideoFull.xml
+++ b/_inc/views/VideoFull.xml
@@ -32,41 +32,6 @@
 			<lineSpacing>1.1</lineSpacing>
 			<zIndex>140</zIndex>
 		</text>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<image name="art" extra="true">
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.5</pos>
@@ -87,16 +52,16 @@
 			<pos>0.13 0.785</pos>
 			<maxSize>0.23 1</maxSize>
 			<zIndex>170</zIndex>
-<storyboard event="activate">
-<animation property="x" to="-0.5" begin="1200" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
-<storyboard event="scroll">
-<animation property="x" to="-0.5" begin="1200" duration="300" mode="EaseIn"/>
-<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
-<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
-</storyboard>
+			<storyboard event="activate">
+				<animation property="x" to="-0.5" begin="1200" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
+			</storyboard>
+			<storyboard event="scroll">
+				<animation property="x" to="-0.5" begin="1200" duration="300" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" duration="150" mode="Linear"/>
+				<animation property="opacity" from="1" to="1" begin="1150" duration="35" mode="Linear"/>
+			</storyboard>
 		</image>
 		<image name="md-description-border" extra="true">
 			<visible>false</visible>
@@ -280,4 +245,6 @@
 			<zIndex>1</zIndex>
 		</image>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/Wallpapers.xml
+++ b/_inc/views/Wallpapers.xml
@@ -13,41 +13,6 @@
 			<lineSpacing>1.1</lineSpacing>
 			<zIndex>140</zIndex>
 		</text>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<image name="art" extra="true">
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.5</pos>
@@ -196,4 +161,6 @@
 			<zIndex>150</zIndex>
 		</image>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/WallpapersCarousel.xml
+++ b/_inc/views/WallpapersCarousel.xml
@@ -98,41 +98,6 @@
 			<lineSpacing>1.1</lineSpacing>
 			<zIndex>140</zIndex>
 		</text>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<image name="art" extra="true">
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.5</pos>
@@ -273,4 +238,6 @@
 			<zIndex>150</zIndex>
 		</image>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/WallpapersHeroes.xml
+++ b/_inc/views/WallpapersHeroes.xml
@@ -32,41 +32,6 @@
 			<lineSpacing>1.1</lineSpacing>
 			<zIndex>140</zIndex>
 		</text>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<image name="art" extra="true">
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.5</pos>
@@ -372,4 +337,6 @@
 			<zIndex>150</zIndex>
 		</image>
 	</customView>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/arrows.xml
+++ b/_inc/views/arrows.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <theme>
     <formatVersion>7</formatVersion>
+    <!-- Moves Battery and network indicators to the left -->
+    <view name="screen">
+        <batteryIndicator name="batteryIndicator">
+            <pos>0.925 0.0</pos>
+        </batteryIndicator>
+    </view>
+    <!-- Displays navigation arrows -->
     <customView name="system,menu,basic,Carousel + Details + Marquee,Carousel + Details,Carousel,Colorful (horizontally),Colorful (vertically),Colorful + Gamelist (horizontally),Colorful + Gamelist (vertically),Colorful + Wheel Left (horizontally),Colorful + Wheel Left (vertically),Colorful + Wheel Right (horizontally),Colorful + Wheel Right (vertically),Detailed No Video,detailed,DetailedWheel,gamecarousel,Grid + Details + Marquee,Grid + Details,grid,Icons,Logo + Details,Tiles + Video,Tiles,Wallpapers,WallpapersCarousel,Detailed Dark,WallpapersHeroes,VideoFull">
         <image name="ArrowBG" extra="static">
             <zIndex>175</zIndex>

--- a/_inc/views/arrows.xml
+++ b/_inc/views/arrows.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<theme>
+    <formatVersion>7</formatVersion>
+    <customView name="system,menu,basic,Carousel + Details + Marquee,Carousel + Details,Carousel,Colorful (horizontally),Colorful (vertically),Colorful + Gamelist (horizontally),Colorful + Gamelist (vertically),Colorful + Wheel Left (horizontally),Colorful + Wheel Left (vertically),Colorful + Wheel Right (horizontally),Colorful + Wheel Right (vertically),Detailed No Video,detailed,DetailedWheel,gamecarousel,Grid + Details + Marquee,Grid + Details,grid,Icons,Logo + Details,Tiles + Video,Tiles,Wallpapers,WallpapersCarousel,Detailed Dark,WallpapersHeroes,VideoFull">
+        <image name="ArrowBG" extra="static">
+            <zIndex>175</zIndex>
+            <color>141414</color>
+            <path>./../../_inc/images/arrow_bg.jpg</path>
+            <path>./../../_inc/images/arrow_bg.png</path>
+            <pos>0.98 0.018</pos>
+            <maxSize>0.04</maxSize>
+            <origin>0.5 0.5</origin>
+        </image>
+        <image name="ArrowUp" extra="static">
+            <zIndex>176</zIndex>
+            <color>666666</color>
+            <path>./../../_inc/images/arrow_up.jpg</path>
+            <path>./../../_inc/images/arrow_up.png</path>
+            <pos>0.97 0.018</pos>
+            <maxSize>0.015</maxSize>
+            <storyboard repeat="forever">
+                <animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
+                <animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
+            </storyboard>
+            <origin>0.5 0.5</origin>
+        </image>
+        <image name="ArrowDown" extra="static">
+            <zIndex>176</zIndex>
+            <color>666666</color>
+            <path>./../../_inc/images/arrow_down.jpg</path>
+            <path>./../../_inc/images/arrow_down.png</path>
+            <pos>0.991 0.018</pos>
+            <maxSize>0.015</maxSize>
+            <storyboard repeat="forever">
+                <animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
+                <animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
+            </storyboard>
+            <origin>0.5 0.5</origin>
+        </image>
+    </customView>
+</theme>

--- a/_inc/views/basic.xml
+++ b/_inc/views/basic.xml
@@ -21,41 +21,6 @@
 			<path>./../../_inc/images/space.png</path>
 			<color>141414</color>
 		</image>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>175</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<image name="logo">
 			<path>./../../_inc/logos/${system.theme}.png</path>
 			<path>./../../_inc/logos/${system.theme}-${lang}.png</path>
@@ -83,4 +48,6 @@
 			<scrollbarAlignment>outerright</scrollbarAlignment>
 		</textlist>
 	</view>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/detailed.xml
+++ b/_inc/views/detailed.xml
@@ -19,41 +19,6 @@
 			<fontPath>./../../_inc/fonts/ubuntu_condensed.ttf</fontPath>
 			<fontSize>0.0194444444444444</fontSize>
 		</datetime>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.98 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.97 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.991 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<video name="md_video">
 			<pos>0.540625 0.480555555555556</pos>
 			<maxSize>0.30 0.3833333333333333</maxSize>
@@ -335,4 +300,6 @@
 			<zIndex>150</zIndex>
 		</image>
 	</view>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/_inc/views/gamecarousel.xml
+++ b/_inc/views/gamecarousel.xml
@@ -19,41 +19,6 @@
 			<fontPath>./../../_inc/fonts/ubuntu_condensed.ttf</fontPath>
 			<fontSize>0.0194444444444444</fontSize>
 		</datetime>
-		<image name="ArrowBG" extra="static">
-			<zIndex>175</zIndex>
-			<color>141414</color>
-			<path>./../../_inc/images/arrow_bg.jpg</path>
-			<path>./../../_inc/images/arrow_bg.png</path>
-			<pos>0.745 0.018</pos>
-			<maxSize>0.04</maxSize>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowUp" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_up.jpg</path>
-			<path>./../../_inc/images/arrow_up.png</path>
-			<pos>0.735 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.010" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.010" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
-		<image name="ArrowDown" extra="static">
-			<zIndex>176</zIndex>
-			<color>666666</color>
-			<path>./../../_inc/images/arrow_down.jpg</path>
-			<path>./../../_inc/images/arrow_down.png</path>
-			<pos>0.756 0.018</pos>
-			<maxSize>0.015</maxSize>
-			<storyboard repeat="forever">
-				<animation property="y" from="0.018" to="0.025" begin="0" duration="700" mode="linear"/>
-				<animation property="y" from="0.025" to="0.018" begin="700" duration="700" mode="linear"/>
-			</storyboard>
-			<origin>0.5 0.5</origin>
-		</image>
 		<video name="md_video">
 			<pos>0.540625 0.480555555555556</pos>
 			<maxSize>0.30 0.3833333333333333</maxSize>
@@ -338,4 +303,6 @@
 			<zIndex>150</zIndex>
 		</image>
 	</view>
+<!-- Navigation arrows, if enabled -->
+  	<include ifSubset="arrows:On">./../../_inc/views/arrows.xml</include>
 </theme>

--- a/theme.xml
+++ b/theme.xml
@@ -25,6 +25,9 @@ originally based on:	art from "Colorful" by viking
 		<gamelist_logo>Gamelist Logo Animate</gamelist_logo>
 		<On_Logo>On</On_Logo>
 		<Off_Logo>Off</Off_Logo>
+		<arrows>Up/Down arrows in System view</arrows>
+		<on_arrows>On</on_arrows>
+		<off_arrows>Off</off_arrows>
 		<VideoFullName>Fullscreen Video</VideoFullName>
 	</variables>
 	
@@ -273,12 +276,18 @@ originally based on:	art from "Colorful" by viking
 <!-- Пресеты -->
 	<include>./_inc/presets/${system.theme}.xml</include>
 
+<!-- Animated gamelist logo on/off -->
 	<subset name="gamelist_logo" displayName="${gamelist_logo}">
 		<include name="On" displayName="${On_Logo}">./_inc/views/gamelist_logo.xml</include>
 		<include name="On (No Black Bars)" displayName="${On_Logo2}">./_inc/views/gamelist_logo_noblack.xml</include>
 		<include name="Off" displayName="${Off_Logo}"></include>
 	</subset>
 
+<!-- Enable/Disable navigation arrows in systemview -->
+	<subset name="arrows" displayName="${arrows}">
+		<include name="On" displayName="${on_arrows}">./_inc/views/arrows.xml</include>
+		<include name="Off" displayName="${off_arrows}"></include>
+	</subset>
 
 <!-- Кнопки -
 	<view name="menu, system, basic, detailed, grid, gamecarousel">

--- a/theme.xml
+++ b/theme.xml
@@ -12,7 +12,7 @@ originally based on:	art from "Colorful" by viking
 <theme defaultView="WallpapersHeroes">
 	<formatVersion>7</formatVersion>
 
-<!-- Кнопки -->
+<!-- English -->
 	<variables>
 		<helpSubsetName>Buttons icons</helpSubsetName>
 		<helpbuttons>Button</helpbuttons>
@@ -25,13 +25,13 @@ originally based on:	art from "Colorful" by viking
 		<gamelist_logo>Gamelist Logo Animate</gamelist_logo>
 		<On_Logo>On</On_Logo>
 		<Off_Logo>Off</Off_Logo>
-		<arrows>Up/Down arrows in System view</arrows>
+		<arrows>Up/Down navigation arrows</arrows>
 		<on_arrows>On</on_arrows>
 		<off_arrows>Off</off_arrows>
 		<VideoFullName>Fullscreen Video</VideoFullName>
 	</variables>
 	
-<!-- Языки -->
+<!-- Other languages -->
 	<variables lang="ru">
 		<subset.colorset>Выбор цвета</subset.colorset>
 		<blue>Синий</blue>
@@ -206,7 +206,7 @@ originally based on:	art from "Colorful" by viking
 		<Art2_169></Art2_169>
 	</variables>
 
-<!-- Цвета -->
+<!-- Colorsets -->
 	<include subset="colorset" name="Blue" displayName="${blue}">./_inc/colors/blue.xml</include>
 	<include subset="colorset" name="Cyan" displayName="${cyan}">./_inc/colors/cyan.xml</include>
 	<include subset="colorset" name="Gray" displayName="${gray}">./_inc/colors/gray.xml</include>
@@ -215,79 +215,6 @@ originally based on:	art from "Colorful" by viking
 	<include subset="colorset" name="Red" displayName="${red}">./_inc/colors/red.xml</include>
 	<include subset="colorset" name="Violet" displayName="${violet}">./_inc/colors/violet.xml</include>
 	<include subset="colorset" name="Yellow" displayName="${yellow}">./_inc/colors/yellow.xml</include>
-
-<!-- Карусель -->
-	<include subset="systemview" name="Wheel (anim)" displayName="${swheelanim}">./_inc/systemviews/wheel_anim.xml</include>
-	<include subset="systemview" name="Wheel" displayName="${swheel}">./_inc/systemviews/wheel.xml</include>
-	<include subset="systemview" name="Wheel Left (anim)" displayName="${swheelleftanim}">./_inc/systemviews/wheel_left_anim.xml</include>
-	<include subset="systemview" name="Wheel Left" displayName="${swheelleft}">./_inc/systemviews/wheel_left.xml</include>
-	<include subset="systemview" name="Simple (anim)" displayName="${ssimple}">./_inc/systemviews/simple.xml</include>
-	<include subset="systemview" name="Vertical (anim)" displayName="${sverticalanim}">./_inc/systemviews/vertical_anim.xml</include>
-	<include subset="systemview" name="Vertical" displayName="${svertical}">./_inc/systemviews/vertical.xml</include>
-	<include subset="systemview" name="Vertical Left (anim)" displayName="${sverticalleftanim}">./_inc/systemviews/vertical_left_anim.xml</include>
-	<include subset="systemview" name="Vertical Left" displayName="${sverticalleft}">./_inc/systemviews/vertical_left.xml</include>
-	<include subset="systemview" name="Horizontal" displayName="${shorizontal}">./_inc/systemviews/horizontal.xml</include>
-	<include subset="systemview" name="Horizontal (anim)" displayName="${shorizontalanim}">./_inc/systemviews/horizontal_anim.xml</include>
-	<include subset="systemview" name="Center" displayName="${scenter}">./_inc/systemviews/center.xml</include>
-
-<!-- Вид систем -->
-	<include subset="systembackground" name="Colorful (anim)" displayName="${ColorfulAnim}">./_inc/systemviews/animate.xml</include>
-	<include subset="systembackground" name="Colorful (anim, transparent)" displayName="${ColorfulAnimTransparent}">./_inc/systemviews/animatetransparent.xml</include>
-	<include subset="systembackground" name="Colorful (no anim)" displayName="${ColorfulNoAnim}">./_inc/systemviews/noanimate.xml</include>
-	<include subset="systembackground" name="Darkful (anim)" displayName="${DarkfulAnim}">./_inc/systemviews/animatedark.xml</include>
-	<include subset="systembackground" name="Darkful (no anim)" displayName="${DarkfulNoAnim}">./_inc/systemviews/noanimatedark.xml</include>
-	<include subset="systembackground" name="Consoles (RPi3, Set VRAM Limit to 80)" displayName="${Art_169}">./_inc/systemviews/art_169.xml</include>
-	<include subset="systembackground" name="Wallpapers (RPi3, Set VRAM Limit to 80)" displayName="${Art2_169}">./_inc/systemviews/art2_169.xml</include>
-	<include subset="systembackground" name="Cinematic FullScreen (Need Disable Video Optimize VRAM Use)" displayName="${CV1}">./_inc/systemviews/cinematic.xml</include>
-	<include subset="systembackground" name="Cinematic Static (put static.mp4 in videos)" displayName="${CV2}">./_inc/systemviews/cinematic_static.xml</include>
-
-	<include tinyScreen="true" name="TinyScreen">./_inc/systemviews/tinyscreen.xml</include>
-
-<!-- Вид списка игр -->
-	<include>./_inc/views/basic.xml</include>
-	<include>./_inc/views/detailed.xml</include>
-	<include>./_inc/views/Detailed Dark.xml</include>
-	<include>./_inc/views/Detailed No Video.xml</include>
-	<include>./_inc/views/gamecarousel.xml</include>
-	<include>./_inc/views/DetailedWheel.xml</include>
-	<include>./_inc/views/grid.xml</include>
-	<include>./_inc/views/Grid + Details.xml</include>
-	<include>./_inc/views/Grid + Details + Marquee.xml</include>
-	<include>./_inc/views/Logo + Details.xml</include>
-	<include>./_inc/views/Wallpapers.xml</include>
-	<include>./_inc/views/WallpapersCarousel.xml</include>
-	<include>./_inc/views/WallpapersHeroes.xml</include>
-	<include>./_inc/views/VideoFull.xml</include>
-	<include>./_inc/views/Carousel.xml</include>
-	<include>./_inc/views/Carousel + Details.xml</include>
-	<include>./_inc/views/Carousel + Details + Marquee.xml</include>
-	<include>./_inc/views/Tiles.xml</include>
-	<include>./_inc/views/Tiles + Video.xml</include>
-	<include>./_inc/views/Icons.xml</include>
-	<include>./_inc/views/Colorful (vertically).xml</include>
-	<include>./_inc/views/Colorful + Gamelist (vertically).xml</include>
-	<include>./_inc/views/Colorful + Wheel Left (vertically).xml</include>
-	<include>./_inc/views/Colorful + Wheel Right (vertically).xml</include>
-	<include>./_inc/views/Colorful (horizontally).xml</include>
-	<include>./_inc/views/Colorful + Gamelist (horizontally).xml</include>
-	<include>./_inc/views/Colorful + Wheel Left (horizontally).xml</include>
-	<include>./_inc/views/Colorful + Wheel Right (horizontally).xml</include>
-
-<!-- Пресеты -->
-	<include>./_inc/presets/${system.theme}.xml</include>
-
-<!-- Animated gamelist logo on/off -->
-	<subset name="gamelist_logo" displayName="${gamelist_logo}">
-		<include name="On" displayName="${On_Logo}">./_inc/views/gamelist_logo.xml</include>
-		<include name="On (No Black Bars)" displayName="${On_Logo2}">./_inc/views/gamelist_logo_noblack.xml</include>
-		<include name="Off" displayName="${Off_Logo}"></include>
-	</subset>
-
-<!-- Enable/Disable navigation arrows in systemview -->
-	<subset name="arrows" displayName="${arrows}">
-		<include name="On" displayName="${on_arrows}">./_inc/views/arrows.xml</include>
-		<include name="Off" displayName="${off_arrows}"></include>
-	</subset>
 
 <!-- Кнопки -
 	<view name="menu, system, basic, detailed, grid, gamecarousel">
@@ -302,11 +229,9 @@ originally based on:	art from "Colorful" by viking
 			<textColor>666666FF</textColor>
 			<iconColor>666666FF</iconColor>
 		</helpsystem>
-	</view>->
+	</view>-->
 
-
-
-<!-- Меню -->
+<!-- Menu -->
 	<view name="menu">
 		<menuText name="menutitle">
 			<fontPath>./_inc/fonts/ubuntu_condensed.ttf</fontPath>
@@ -361,7 +286,7 @@ originally based on:	art from "Colorful" by viking
 		</menuTextEdit>
 	</view>
 
-<!-- Часы, иконки геймпадов, лого -->
+<!-- Clock, gamepad icons, battery indicator -->
 	<view name="screen">
 		<text name="clock">
 			<color>777777FF</color>
@@ -383,7 +308,7 @@ originally based on:	art from "Colorful" by viking
 			<hotkeyColor>FF0000</hotkeyColor>
 		</controllerActivity>
 		<batteryIndicator name="batteryIndicator">
-			<pos>0.925 0.0</pos>
+			<pos>0.96 0.0</pos>
 			<size>0.033 0.0275</size>
 			<horizontalAlignment>right</horizontalAlignment>
 			<incharge>./_inc/images/battery/incharge.svg</incharge>
@@ -459,7 +384,90 @@ originally based on:	art from "Colorful" by viking
 		</text>
 	</view>
 
-<!-- Вид списка игр -->
+<!-- Buttons -->
+	<subset name="helpsystem" displayName="${helpSubsetName}">
+		<include name="buttons" displayName="${helpbuttons}">./_inc/help/buttons.xml</include>
+		<include name="xboxbuttons" displayName="${xboxbuttons}">./_inc/help/xboxbuttons.xml</include>
+		<include name="psxbuttons" displayName="${psxbuttons}">./_inc/help/psxbuttons.xml</include>
+		<include name="psxbuttons_color" displayName="${psxbuttons_color}">./_inc/help/psxbuttons_color.xml</include>
+		<include name="arcadebuttons" displayName="${arcadebuttons}">./_inc/help/arcadebuttons.xml</include>
+		<include name="standard" displayName="${stbuttons}">./_inc/help/default.xml</include>
+	</subset>
+
+<!-- System views -->
+	<include subset="systemview" name="Wheel (anim)" displayName="${swheelanim}">./_inc/systemviews/wheel_anim.xml</include>
+	<include subset="systemview" name="Wheel" displayName="${swheel}">./_inc/systemviews/wheel.xml</include>
+	<include subset="systemview" name="Wheel Left (anim)" displayName="${swheelleftanim}">./_inc/systemviews/wheel_left_anim.xml</include>
+	<include subset="systemview" name="Wheel Left" displayName="${swheelleft}">./_inc/systemviews/wheel_left.xml</include>
+	<include subset="systemview" name="Simple (anim)" displayName="${ssimple}">./_inc/systemviews/simple.xml</include>
+	<include subset="systemview" name="Vertical (anim)" displayName="${sverticalanim}">./_inc/systemviews/vertical_anim.xml</include>
+	<include subset="systemview" name="Vertical" displayName="${svertical}">./_inc/systemviews/vertical.xml</include>
+	<include subset="systemview" name="Vertical Left (anim)" displayName="${sverticalleftanim}">./_inc/systemviews/vertical_left_anim.xml</include>
+	<include subset="systemview" name="Vertical Left" displayName="${sverticalleft}">./_inc/systemviews/vertical_left.xml</include>
+	<include subset="systemview" name="Horizontal" displayName="${shorizontal}">./_inc/systemviews/horizontal.xml</include>
+	<include subset="systemview" name="Horizontal (anim)" displayName="${shorizontalanim}">./_inc/systemviews/horizontal_anim.xml</include>
+	<include subset="systemview" name="Center" displayName="${scenter}">./_inc/systemviews/center.xml</include>
+
+<!-- System backgrounds -->
+	<include subset="systembackground" name="Colorful (anim)" displayName="${ColorfulAnim}">./_inc/systemviews/animate.xml</include>
+	<include subset="systembackground" name="Colorful (anim, transparent)" displayName="${ColorfulAnimTransparent}">./_inc/systemviews/animatetransparent.xml</include>
+	<include subset="systembackground" name="Colorful (no anim)" displayName="${ColorfulNoAnim}">./_inc/systemviews/noanimate.xml</include>
+	<include subset="systembackground" name="Darkful (anim)" displayName="${DarkfulAnim}">./_inc/systemviews/animatedark.xml</include>
+	<include subset="systembackground" name="Darkful (no anim)" displayName="${DarkfulNoAnim}">./_inc/systemviews/noanimatedark.xml</include>
+	<include subset="systembackground" name="Consoles (RPi3, Set VRAM Limit to 80)" displayName="${Art_169}">./_inc/systemviews/art_169.xml</include>
+	<include subset="systembackground" name="Wallpapers (RPi3, Set VRAM Limit to 80)" displayName="${Art2_169}">./_inc/systemviews/art2_169.xml</include>
+	<include subset="systembackground" name="Cinematic FullScreen (Need Disable Video Optimize VRAM Use)" displayName="${CV1}">./_inc/systemviews/cinematic.xml</include>
+	<include subset="systembackground" name="Cinematic Static (put static.mp4 in videos)" displayName="${CV2}">./_inc/systemviews/cinematic_static.xml</include>
+
+	<include tinyScreen="true" name="TinyScreen">./_inc/systemviews/tinyscreen.xml</include>
+
+<!-- Animated gamelist logo on/off -->
+	<subset name="gamelist_logo" displayName="${gamelist_logo}">
+		<include name="On" displayName="${On_Logo}">./_inc/views/gamelist_logo.xml</include>
+		<include name="On (No Black Bars)" displayName="${On_Logo2}">./_inc/views/gamelist_logo_noblack.xml</include>
+		<include name="Off" displayName="${Off_Logo}"></include>
+	</subset>
+
+<!-- Enable/Disable navigation arrows in System view -->
+	<subset name="arrows" displayName="${arrows}">
+		<include name="On" displayName="${on_arrows}"></include>
+		<include name="Off" displayName="${off_arrows}"></include>
+	</subset>
+
+<!-- Game views -->
+	<include>./_inc/views/basic.xml</include>
+	<include>./_inc/views/detailed.xml</include>
+	<include>./_inc/views/Detailed Dark.xml</include>
+	<include>./_inc/views/Detailed No Video.xml</include>
+	<include>./_inc/views/gamecarousel.xml</include>
+	<include>./_inc/views/DetailedWheel.xml</include>
+	<include>./_inc/views/grid.xml</include>
+	<include>./_inc/views/Grid + Details.xml</include>
+	<include>./_inc/views/Grid + Details + Marquee.xml</include>
+	<include>./_inc/views/Logo + Details.xml</include>
+	<include>./_inc/views/Wallpapers.xml</include>
+	<include>./_inc/views/WallpapersCarousel.xml</include>
+	<include>./_inc/views/WallpapersHeroes.xml</include>
+	<include>./_inc/views/VideoFull.xml</include>
+	<include>./_inc/views/Carousel.xml</include>
+	<include>./_inc/views/Carousel + Details.xml</include>
+	<include>./_inc/views/Carousel + Details + Marquee.xml</include>
+	<include>./_inc/views/Tiles.xml</include>
+	<include>./_inc/views/Tiles + Video.xml</include>
+	<include>./_inc/views/Icons.xml</include>
+	<include>./_inc/views/Colorful (vertically).xml</include>
+	<include>./_inc/views/Colorful + Gamelist (vertically).xml</include>
+	<include>./_inc/views/Colorful + Wheel Left (vertically).xml</include>
+	<include>./_inc/views/Colorful + Wheel Right (vertically).xml</include>
+	<include>./_inc/views/Colorful (horizontally).xml</include>
+	<include>./_inc/views/Colorful + Gamelist (horizontally).xml</include>
+	<include>./_inc/views/Colorful + Wheel Left (horizontally).xml</include>
+	<include>./_inc/views/Colorful + Wheel Right (horizontally).xml</include>
+
+<!-- Presets -->
+	<include>./_inc/presets/${system.theme}.xml</include>
+
+<!-- Game views (common elements) -->
 	<view name="basic,detailed,grid,gamecarousel">
 		<image name="logo">
 			<path>./_inc/logos/${system.theme}.png</path>
@@ -525,17 +533,7 @@ originally based on:	art from "Colorful" by viking
 		</text>-->
 	</view>
 
-<!-- Кнопки -->
-	<subset name="helpsystem" displayName="${helpSubsetName}">
-		<include name="buttons" displayName="${helpbuttons}">./_inc/help/buttons.xml</include>
-		<include name="xboxbuttons" displayName="${xboxbuttons}">./_inc/help/xboxbuttons.xml</include>
-		<include name="psxbuttons" displayName="${psxbuttons}">./_inc/help/psxbuttons.xml</include>
-		<include name="psxbuttons_color" displayName="${psxbuttons_color}">./_inc/help/psxbuttons_color.xml</include>
-		<include name="arcadebuttons" displayName="${arcadebuttons}">./_inc/help/arcadebuttons.xml</include>
-		<include name="standard" displayName="${stbuttons}">./_inc/help/default.xml</include>
-	</subset>
-
-<!-- Анимации иконок -->
+<!-- Icon animations in gameviews -->
 <customView name="Colorful + Wheel Right (horizontally), Colorful + Wheel Left (horizontally), Colorful + Gamelist (horizontally), Colorful (horizontally), Colorful + Wheel Right (vertically), Colorful + Wheel Left (vertically), Colorful + Gamelist (vertically), Colorful (vertically)">
 		<image name="gametime_logo,genre_logo,developer_logo,playcount_logo,publisher_logo,release_date_logo,md_kidgame,md_notkidgame,md_hidden,md_savestate,md_nosavestate,md_cheevos,md_notcheevos,md_manual,md_nomanual,md_flag">
 			<storyboard>
@@ -563,7 +561,5 @@ originally based on:	art from "Colorful" by viking
 			</storyboard>
 		</rating>
 </customView>
-
-
 
 </theme>


### PR DESCRIPTION
Added an option to enable/disable navigation arrows (up-down) on the upper right corner of the screen.
If disabled, battery and network indicators position move to the right of the screen.