### PR TITLE
Fix 4k system img path in us/jp regions

### DIFF
--- a/_inc/systemviews/animate.xml
+++ b/_inc/systemviews/animate.xml
@@ -23,14 +23,14 @@
 		<image name="background1" extra="true" region="us">
 			<path>./../../_inc/anim/us/${system.theme}.jpg</path>
 			<path>./../../_inc/anim/us/${system.theme}.png</path>
-			<path>./../../_inc/anim/4K/us/${system.theme}.jpg</path>
-			<path>./../../_inc/anim/4K/us/${system.theme}.png</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/us/${system.theme}.jpg</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/us/${system.theme}.png</path>
 		</image>
 		<image name="background1" extra="true" region="jp">
 			<path>./../../_inc/anim/jp/${system.theme}.jpg</path>
 			<path>./../../_inc/anim/jp/${system.theme}.png</path>
-			<path>./../../_inc/anim/4K/jp/${system.theme}.jpg</path>
-			<path>./../../_inc/anim/4K/jp/${system.theme}.png</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/jp/${system.theme}.jpg</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/jp/${system.theme}.png</path>
 		</image>
 		<!-- If it's a collection, checks if the the video addon is available -->
 		<video name="md_video" extra="static">

--- a/_inc/systemviews/animatedark.xml
+++ b/_inc/systemviews/animatedark.xml
@@ -22,14 +22,14 @@
 		<image name="background1" extra="true" region="us">
 			<path>./../../_inc/anim/dark/us/${system.theme}.jpg</path>
 			<path>./../../_inc/anim/dark/us/${system.theme}.png</path>
-			<path>./../../_inc/anim/4K/dark/us/${system.theme}.jpg</path>
-			<path>./../../_inc/anim/4K/dark/us/${system.theme}.png</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/dark/us/${system.theme}.jpg</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/dark/us/${system.theme}.png</path>
 		</image>
 		<image name="background1" extra="true" region="jp">
 			<path>./../../_inc/anim/dark/jp/${system.theme}.jpg</path>
 			<path>./../../_inc/anim/dark/jp/${system.theme}.png</path>
-			<path>./../../_inc/anim/4K/dark/jp/${system.theme}.jpg</path>
-			<path>./../../_inc/anim/4K/dark/jp/${system.theme}.png</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/dark/jp/${system.theme}.jpg</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/dark/jp/${system.theme}.png</path>
 		</image>
 		<!-- If it's a collection, checks if the the video addon is available -->
 		<video name="md_video" extra="static">

--- a/_inc/systemviews/animatetransparent.xml
+++ b/_inc/systemviews/animatetransparent.xml
@@ -22,14 +22,14 @@
 		<image name="background1" extra="true" region="us">
 			<path>./../../_inc/anim/us/${system.theme}.jpg</path>
 			<path>./../../_inc/anim/us/${system.theme}.png</path>
-			<path>./../../_inc/anim/4K/us/${system.theme}.jpg</path>
-			<path>./../../_inc/anim/4K/us/${system.theme}.png</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/us/${system.theme}.jpg</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/us/${system.theme}.png</path>
 		</image>
 		<image name="background1" extra="true" region="jp">
 			<path>./../../_inc/anim/jp/${system.theme}.jpg</path>
 			<path>./../../_inc/anim/jp/${system.theme}.png</path>
-			<path>./../../_inc/anim/4K/jp/${system.theme}.jpg</path>
-			<path>./../../_inc/anim/4K/jp/${system.theme}.png</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/jp/${system.theme}.jpg</path>
+			<path>./../../../ckau-book-addons/_inc/anim/4K/jp/${system.theme}.png</path>
 		</image>
 		<!-- If it's a collection, checks if the the video addon is available -->
 		<video name="md_video" extra="static">


### PR DESCRIPTION
Fixed path of system image in Colorful/Darkful, when US or JP region is selected. Now points correctly to the new 4K addon path.