### PR TITLE
add jp label to console

### DIFF
--- a/_inc/layouts/dreamcast-jp.xml
+++ b/_inc/layouts/dreamcast-jp.xml
@@ -44,6 +44,16 @@
 		<text name="TextName" extra="true">
 			<text>Dreamcast</text>
 		</text>
+		<text name="TextVariant" extra="true">
+			<text>Japanese version</text>
+			<text lang="pl">Wersja japońska</text>
+			<text lang="ru">Японская версия</text>
+			<text lang="es">Versión japonesa</text>
+			<text lang="de">Japanische Version</text>
+			<text lang="fr">Version japonaise</text>
+			<text lang="it">Versione giapponese</text>
+			<text lang="pt">Versão japonesa</text>
+		</text>
 		<text name="TextDesc" extra="true">
 			<text>The Dreamcast is a home video game console released by Sega on November 27, 1998 in Japan, September 9, 1999 in North America, and October 14, 1999 in Europe. It was the first in the sixth generation of video game consoles, preceding Sony's PlayStation 2, Nintendo's GameCube, and Microsoft's Xbox. The Dreamcast was Sega's final home console, marking the end of the company's eighteen years in the console market.
 

--- a/_inc/layouts/gc-jp.xml
+++ b/_inc/layouts/gc-jp.xml
@@ -46,6 +46,16 @@
 		<text name="TextName" extra="true">
 			<text>GameCube</text>
 		</text>
+		<text name="TextVariant" extra="true">
+			<text>Japanese version</text>
+			<text lang="pl">Wersja japońska</text>
+			<text lang="ru">Японская версия</text>
+			<text lang="es">Versión japonesa</text>
+			<text lang="de">Japanische Version</text>
+			<text lang="fr">Version japonaise</text>
+			<text lang="it">Versione giapponese</text>
+			<text lang="pt">Versão japonesa</text>
+		</text>
 		<text name="TextDesc" extra="true">
 			<text>The Nintendo GameCube is a home video game console released by Nintendo in Japan and North America in 2001 and in PAL territories in 2002. The GameCube is Nintendo's entry in the sixth generation of video game consoles and is the successor to their previous console, the Nintendo 64. The GameCube competed with Sony's PlayStation 2 and Microsoft's Xbox.
 

--- a/_inc/layouts/saturn-jp.xml
+++ b/_inc/layouts/saturn-jp.xml
@@ -53,6 +53,16 @@
 		<text name="TextName" extra="true">
 			<text>Saturn</text>
 		</text>
+		<text name="TextVariant" extra="true">
+			<text>Japanese version</text>
+			<text lang="pl">Wersja japońska</text>
+			<text lang="ru">Японская версия</text>
+			<text lang="es">Versión japonesa</text>
+			<text lang="de">Japanische Version</text>
+			<text lang="fr">Version japonaise</text>
+			<text lang="it">Versione giapponese</text>
+			<text lang="pt">Versão japonesa</text>
+		</text>
 		<text name="TextDesc" extra="true">
 			<text>The Sega Saturn is a home video game console developed by Sega and released on November 22, 1994 in Japan, May 11, 1995 in North America, and July 8, 1995 in Europe. Part of the fifth generation of video game consoles, it was the successor to the successful Sega Genesis. The Saturn has a dual-CPU architecture and eight processors. Its games are in CD-ROM format, and its game library contains several ports of arcade games as well as original games.
 

--- a/_inc/systemcolors/blackful.xml
+++ b/_inc/systemcolors/blackful.xml
@@ -34,6 +34,9 @@
 		<text name="TextName" extra="true">
 			<color>FFFFFF</color>
 		</text>
+		<text name="TextVariant" extra="true">
+			<color>FFFFFF</color>
+		</text>
 		<text name="TextDesc" extra="true">
 			<color>FFFFFF</color>
 		</text>

--- a/_inc/systemcolors/colorful.xml
+++ b/_inc/systemcolors/colorful.xml
@@ -44,6 +44,9 @@
 		<text name="TextName" extra="true">
 			<color>FFFFFF</color>
 		</text>
+		<text name="TextVariant" extra="true">
+			<color>FFFFFF</color>
+		</text>	
 		<text name="TextDesc" extra="true">
 			<color>FFFFFF</color>
 		</text>

--- a/_inc/systemcolors/darkful.xml
+++ b/_inc/systemcolors/darkful.xml
@@ -34,6 +34,9 @@
 		<text name="TextName" extra="true">
 			<color>FFFFFF</color>
 		</text>
+		<text name="TextVariant" extra="true">
+			<color>FFFFFF</color>
+		</text>
 		<text name="TextDesc" extra="true">
 			<color>FFFFFF80</color>
 		</text>

--- a/_inc/systemcolors/greyful.xml
+++ b/_inc/systemcolors/greyful.xml
@@ -34,6 +34,9 @@
 		<text name="TextName" extra="true">
 			<color>FFFFFF</color>
 		</text>
+		<text name="TextVariant" extra="true">
+			<color>FFFFFF</color>
+		</text>
 		<text name="TextDesc" extra="true">
 			<color>000000</color>
 		</text>

--- a/_inc/systemcolors/lightful.xml
+++ b/_inc/systemcolors/lightful.xml
@@ -35,6 +35,9 @@
 		<text name="TextName" extra="true">
 			<color>000000</color>
 		</text>
+		<text name="TextVariant" extra="true">
+			<color>000000</color>
+		</text>
 		<text name="TextDesc" extra="true">
 			<color>000000</color>
 		</text>

--- a/_inc/systemviews/animate.xml
+++ b/_inc/systemviews/animate.xml
@@ -117,6 +117,21 @@
 				<animation property="opacity" from="0" to="1" begin="2500" duration="500" mode="EaseIn"/>
 			</storyboard>
 		</text>
+		<text name="TextVariant" extra="true">
+			<pos>0.49 0.318</pos>
+			<size>0.47 0</size>
+			<autoScroll>vertical</autoScroll>
+			<verticalAlignment>top</verticalAlignment>
+			<fontPath>${fontNameLight}</fontPath>
+			<fontSize>0.02</fontSize>
+			<lineSpacing>1.1</lineSpacing>
+			<zIndex>140</zIndex>
+			<storyboard>
+				<animation property="y" from="0.3" begin="3000" duration="500" mode="linear"/>
+				<animation property="opacity" to="0" begin="0" duration="0" mode="linear"/>
+				<animation property="opacity" from="0" to="1" begin="3000" duration="500" mode="EaseIn"/>
+			</storyboard>
+		</text>
 		<text name="TextDesc" extra="true">
 			<pos>0.49 0.384</pos>
 			<size>0.47 0.51</size>


### PR DESCRIPTION
Added a "Japanese version" label under system name in dreamcast-jp, saturn-jp and gc-jp

![image](https://github.com/user-attachments/assets/f2098cf5-677e-4827-97f9-e334e495bed7)
