### PR TITLE
Performance optimization

### DIFF
--- a/.cursor/rules/video-delay-optimization.mdc
+++ b/.cursor/rules/video-delay-optimization.mdc
@@ -1,0 +1,46 @@
+---
+description: Changelog and documentation for video delay optimization in ckau-book theme
+alwaysApply: true
+---
+
+# Video Delay Optimization - Changelog (January 2026)
+
+## Problem Solved
+Videos in system views were starting too quickly, causing potential GPU crashes as the graphics card didn't have enough time to load the video.
+
+## Changes Applied
+
+### 1. Video Delay (+1 second)
+**Files:** `_inc/layouts/*.xml` (431 files)
+- `<delay>0</delay>` → `<delay>1</delay>`
+- The delay gives the GPU time to load the video without crashing
+
+### 2. Image Animations (+1000ms)
+**Files:** `_inc/layouts/*.xml`
+- `sysbg-video`: `begin="2000"` → `begin="3000"`
+- `videobox`: `begin="2000"` → `begin="2000"` (stays at 2000 because the 1s video delay effectively brings it to 3000ms)
+
+**Files:** `_inc/systemviews/animate.xml` and `animatetransparent.xml`
+- `sysart`: `begin="2000"` → `begin="3000"`
+
+### 3. Text Animations (+1000ms)
+**File:** `_inc/systemviews/animate.xml`
+- `TextManufacturer`: `begin="2500"` → `begin="3500"`
+- `TextName`: `begin="2500"` → `begin="3500"`
+- `TextVariant`: `begin="2500"` → `begin="3500"`
+- `TextDate`: `begin="3000"` → `begin="4000"`
+- `TextDesc`: `begin="3000"` → `begin="4000"`
+
+## Final Timing (from page load)
+| Element | Timing |
+|---------|--------|
+| Video starts loading | 0ms |
+| Video starts playing | 1000ms (delay) |
+| Images + video movement | 3000ms |
+| Manufacturer/Name/Variant texts | 3500ms |
+| Date/Desc texts | 4000ms |
+
+## Important Notes
+- The `<delay>1</delay>` is ESSENTIAL - never remove it
+- Video animation uses `begin="2000"` because it starts after the 1s delay
+- Other animations use `begin="3000"` because they start from page load

--- a/_inc/layouts/3do.xml
+++ b/_inc/layouts/3do.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.325</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.325" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.325" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.26</origin>

--- a/_inc/layouts/3ds.xml
+++ b/_inc/layouts/3ds.xml
@@ -12,7 +12,7 @@
 			<pos>0.503 0.49</pos>
 			<maxSize>0.61</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.223 0.49" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.223 0.49" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.495</origin>

--- a/_inc/layouts/3dsen.xml
+++ b/_inc/layouts/3dsen.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/abc80.xml
+++ b/_inc/layouts/abc80.xml
@@ -13,7 +13,7 @@
 			<pos>0.44 0.4</pos>
 			<maxSize>0.248</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.16 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.16 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/actionmax.xml
+++ b/_inc/layouts/actionmax.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.348</pos>
 			<maxSize>0.29</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.348" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.348" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/adam.xml
+++ b/_inc/layouts/adam.xml
@@ -13,7 +13,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/adrenaline.xml
+++ b/_inc/layouts/adrenaline.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/advision.xml
+++ b/_inc/layouts/advision.xml
@@ -10,7 +10,7 @@
 			<pos>0.5 0.43</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.43" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.43" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -21,7 +21,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.43</pos>

--- a/_inc/layouts/aleck64.xml
+++ b/_inc/layouts/aleck64.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/alice32.xml
+++ b/_inc/layouts/alice32.xml
@@ -13,7 +13,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.28</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.21 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.21 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/amiga.xml
+++ b/_inc/layouts/amiga.xml
@@ -12,7 +12,7 @@
 			<pos>0.51 0.377</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.23 0.377" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.23 0.377" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/amiga1200.xml
+++ b/_inc/layouts/amiga1200.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.354</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.354" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.354" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/amiga3000.xml
+++ b/_inc/layouts/amiga3000.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.354</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.354" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.354" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/amiga4000.xml
+++ b/_inc/layouts/amiga4000.xml
@@ -12,7 +12,7 @@
 			<pos>0.51 0.378</pos>
 			<maxSize>0.242</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.23 0.378" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.23 0.378" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/amiga500.xml
+++ b/_inc/layouts/amiga500.xml
@@ -11,7 +11,7 @@
 			<pos>0.5 0.354</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.354" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.354" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/amiga600.xml
+++ b/_inc/layouts/amiga600.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.354</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.354" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.354" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/amigacd32.xml
+++ b/_inc/layouts/amigacd32.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.348</pos>
 			<maxSize>0.29</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.348" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.348" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/amigacdtv.xml
+++ b/_inc/layouts/amigacdtv.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.348</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.348" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.348" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/amstradcpc.xml
+++ b/_inc/layouts/amstradcpc.xml
@@ -13,7 +13,7 @@
 			<pos>0.4773 0.4</pos>
 			<maxSize>0.238</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.1973 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.1973 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/android.xml
+++ b/_inc/layouts/android.xml
@@ -15,7 +15,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.263" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.263" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -30,7 +30,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.722" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.722" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -43,7 +43,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.559</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.465</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.49" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.49" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -53,7 +53,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.498 0.49</pos>

--- a/_inc/layouts/apfm1000.xml
+++ b/_inc/layouts/apfm1000.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.215</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/apogeebk01.xml
+++ b/_inc/layouts/apogeebk01.xml
@@ -12,7 +12,7 @@
 			<pos>0.501 0.363</pos>
 			<maxSize>0.232</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.285</origin>

--- a/_inc/layouts/apple2.xml
+++ b/_inc/layouts/apple2.xml
@@ -13,7 +13,7 @@
 			<pos>0.482 0.325</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.202 0.325" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.202 0.325" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/apple2gs.xml
+++ b/_inc/layouts/apple2gs.xml
@@ -6,7 +6,7 @@
 			<color>000000</color>
 			<path>./../../_inc/images/space43.png</path>
 			<zIndex>2</zIndex>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>
@@ -14,7 +14,7 @@
 			<pos>0.5 0.355</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.355" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.355" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/appleios.xml
+++ b/_inc/layouts/appleios.xml
@@ -14,7 +14,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.2753" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.2753" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -29,7 +29,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.7175" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.7175" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -42,7 +42,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.5565</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.463</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2195 0.49" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2195 0.49" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -52,7 +52,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.49</pos>

--- a/_inc/layouts/aquarius.xml
+++ b/_inc/layouts/aquarius.xml
@@ -13,7 +13,7 @@
 			<pos>0.48 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.20 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.20 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/arcade.xml
+++ b/_inc/layouts/arcade.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/arcadepc.xml
+++ b/_inc/layouts/arcadepc.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/teknoparrot.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/arcadia.xml
+++ b/_inc/layouts/arcadia.xml
@@ -13,7 +13,7 @@
 			<pos>0.48 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.20 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.20 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/archimedes.xml
+++ b/_inc/layouts/archimedes.xml
@@ -11,7 +11,7 @@
 			<pos>0.499 0.365</pos>
 			<maxSize>0.265</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.365" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.365" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.4</origin>

--- a/_inc/layouts/arduboy.xml
+++ b/_inc/layouts/arduboy.xml
@@ -13,7 +13,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.18</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.15</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.33" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.33" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/astrocde.xml
+++ b/_inc/layouts/astrocde.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/atari2600.xml
+++ b/_inc/layouts/atari2600.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/atari5200.xml
+++ b/_inc/layouts/atari5200.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/atari7800-us.xml
+++ b/_inc/layouts/atari7800-us.xml
@@ -13,7 +13,7 @@
 			<pos>0.475 0.394</pos>
 			<maxSize>0.242</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.394" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.394" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/atari7800.xml
+++ b/_inc/layouts/atari7800.xml
@@ -13,7 +13,7 @@
 			<pos>0.475 0.394</pos>
 			<maxSize>0.242</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.394" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.394" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/atari800.xml
+++ b/_inc/layouts/atari800.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.35</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.35" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.35" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.28</origin>

--- a/_inc/layouts/atarijaguar.xml
+++ b/_inc/layouts/atarijaguar.xml
@@ -12,7 +12,7 @@
 			<pos>0.4995 0.39</pos>
 			<maxSize>0.252</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2195 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2195 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/atarijaguarcd.xml
+++ b/_inc/layouts/atarijaguarcd.xml
@@ -12,7 +12,7 @@
 			<pos>0.4995 0.39</pos>
 			<maxSize>0.252</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2195 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2195 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/atarilynx.xml
+++ b/_inc/layouts/atarilynx.xml
@@ -11,7 +11,7 @@
 			<maxSize>0.19</maxSize>
 			<maxSize if="${screen.ratio} == '4/3'">0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -21,7 +21,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.5</pos>

--- a/_inc/layouts/atarist.xml
+++ b/_inc/layouts/atarist.xml
@@ -13,7 +13,7 @@
 			<pos>0.522 0.415</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.242 0.415" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.242 0.415" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/atom.xml
+++ b/_inc/layouts/atom.xml
@@ -14,7 +14,7 @@
 			<maxSize>0.242</maxSize>
 			<maxSize if="${screen.ratio} == '4/3'">0.234</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.209 0.395" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.209 0.395" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/atomiswave.xml
+++ b/_inc/layouts/atomiswave.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.007 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.007 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.433 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.433 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -44,7 +44,7 @@
 			<size if="${screen.ratio} == '16/10'">0.39 0.22</size>
 			<size if="${screen.ratio} == '21/9'">0.28 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -53,7 +53,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/auto-action.xml
+++ b/_inc/layouts/auto-action.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-adventure.xml
+++ b/_inc/layouts/auto-adventure.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-allgames.xml
+++ b/_inc/layouts/auto-allgames.xml
@@ -12,7 +12,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -23,7 +23,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -34,7 +34,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '21/9'">0.494 0.5</origin>

--- a/_inc/layouts/auto-at2players.xml
+++ b/_inc/layouts/auto-at2players.xml
@@ -14,7 +14,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.18" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.18" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -29,7 +29,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.65" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.65" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -44,7 +44,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -54,7 +54,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/auto-at4players.xml
+++ b/_inc/layouts/auto-at4players.xml
@@ -14,7 +14,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.18" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.18" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -29,7 +29,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.65" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.65" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -44,7 +44,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -54,7 +54,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/auto-beatemup.xml
+++ b/_inc/layouts/auto-beatemup.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-favorites.xml
+++ b/_inc/layouts/auto-favorites.xml
@@ -16,7 +16,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -27,7 +27,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -38,7 +38,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '21/9'">0.494 0.5</origin>

--- a/_inc/layouts/auto-fight.xml
+++ b/_inc/layouts/auto-fight.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-huntingandfishing.xml
+++ b/_inc/layouts/auto-huntingandfishing.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-lastplayed.xml
+++ b/_inc/layouts/auto-lastplayed.xml
@@ -16,7 +16,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 
@@ -28,7 +28,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -40,7 +40,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>

--- a/_inc/layouts/auto-lastplayed.xml
+++ b/_inc/layouts/auto-lastplayed.xml
@@ -14,7 +14,7 @@
 			<scale if="${screen.ratio} == '16/10'">0.9</scale>
 			<scale if="${screen.ratio} == '4/3'">0.75</scale>
 			<path>./../../_inc/anim/auto-fix.png</path>
-			<zIndex>26</zIndex>
+			<zIndex>27</zIndex>
 			<storyboard>
 				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
@@ -45,7 +45,7 @@
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
 			<pos>0.508 0.492</pos>
-			<maxSize>0.103</maxSize>
+			<maxSize>0.085</maxSize>
 			<rotation>-2</rotation>
 			<zIndex>26</zIndex>
 			<storyboard>

--- a/_inc/layouts/auto-neverplayed.xml
+++ b/_inc/layouts/auto-neverplayed.xml
@@ -16,7 +16,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 
@@ -28,7 +28,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -40,7 +40,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>

--- a/_inc/layouts/auto-pinball.xml
+++ b/_inc/layouts/auto-pinball.xml
@@ -16,7 +16,7 @@
 			<pos>0.501 0.405</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/fpinball.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.395</origin>

--- a/_inc/layouts/auto-platform.xml
+++ b/_inc/layouts/auto-platform.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-playingcards.xml
+++ b/_inc/layouts/auto-playingcards.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-puzzle.xml
+++ b/_inc/layouts/auto-puzzle.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-quiz.xml
+++ b/_inc/layouts/auto-quiz.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-racedriving.xml
+++ b/_inc/layouts/auto-racedriving.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-reflection.xml
+++ b/_inc/layouts/auto-reflection.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-roleplayings.xml
+++ b/_inc/layouts/auto-roleplayings.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-runandgun.xml
+++ b/_inc/layouts/auto-runandgun.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-shootemup.xml
+++ b/_inc/layouts/auto-shootemup.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-shooter.xml
+++ b/_inc/layouts/auto-shooter.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-sports.xml
+++ b/_inc/layouts/auto-sports.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-sportswithanimals.xml
+++ b/_inc/layouts/auto-sportswithanimals.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-strategy.xml
+++ b/_inc/layouts/auto-strategy.xml
@@ -11,7 +11,7 @@
 			<path>./../../_inc/anim/auto-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -22,7 +22,7 @@
 			<pos>0.5 0.492</pos>
 			<maxSize>0.6</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.492" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.492" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -33,7 +33,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}-${lang}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>
@@ -48,7 +48,7 @@
 		<video name="videobox2" extra="true">
 			<path>./../../_inc/anim/video/favorites2.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/favorites2.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.49 0.4929</pos>

--- a/_inc/layouts/auto-trackball.xml
+++ b/_inc/layouts/auto-trackball.xml
@@ -14,7 +14,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.18" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.18" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -29,7 +29,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.65" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.65" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -44,7 +44,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -53,7 +53,7 @@
 			<path>./../../_inc/anim/video/${synonym}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/auto-verticalarcade.xml
+++ b/_inc/layouts/auto-verticalarcade.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.01 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.01 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.43 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.43 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -43,7 +43,7 @@
 			<size if="${screen.ratio} == '4/3'">0.38 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.28 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -52,7 +52,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/cave.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/auto-wheel.xml
+++ b/_inc/layouts/auto-wheel.xml
@@ -14,7 +14,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.18" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.18" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -29,7 +29,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.65" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.65" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -44,7 +44,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -55,7 +55,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/avgn.xml
+++ b/_inc/layouts/avgn.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.325</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.325" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.325" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.26</origin>

--- a/_inc/layouts/batoparrot.xml
+++ b/_inc/layouts/batoparrot.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/teknoparrot.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/bbcmicro.xml
+++ b/_inc/layouts/bbcmicro.xml
@@ -12,7 +12,7 @@
 			<pos>0.452 0.439</pos>
 			<maxSize>0.235</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.172 0.439" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.172 0.439" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.4</origin>

--- a/_inc/layouts/beena.xml
+++ b/_inc/layouts/beena.xml
@@ -13,7 +13,7 @@
 			<pos>0.422 0.382</pos>
 			<maxSize>0.252</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.142 0.382" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.142 0.382" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/bk001001.xml
+++ b/_inc/layouts/bk001001.xml
@@ -12,7 +12,7 @@
 			<pos>0.501 0.363</pos>
 			<maxSize>0.232</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.285</origin>

--- a/_inc/layouts/bml3.xml
+++ b/_inc/layouts/bml3.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.285</origin>

--- a/_inc/layouts/boom3.xml
+++ b/_inc/layouts/boom3.xml
@@ -15,7 +15,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2101 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2101 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/bstone.xml
+++ b/_inc/layouts/bstone.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.36</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.31</origin>

--- a/_inc/layouts/c128.xml
+++ b/_inc/layouts/c128.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.354</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.354" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.354" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/c16.xml
+++ b/_inc/layouts/c16.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.356</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.356" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.356" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.26</origin>

--- a/_inc/layouts/c20.xml
+++ b/_inc/layouts/c20.xml
@@ -13,7 +13,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/c64.xml
+++ b/_inc/layouts/c64.xml
@@ -13,7 +13,7 @@
 			<pos>0.518 0.33</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.238 0.33" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.238 0.33" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.2</origin>

--- a/_inc/layouts/c64gs.xml
+++ b/_inc/layouts/c64gs.xml
@@ -13,7 +13,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.28</origin>

--- a/_inc/layouts/camplynx.xml
+++ b/_inc/layouts/camplynx.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.336</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.336" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.336" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/captpower.xml
+++ b/_inc/layouts/captpower.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.325</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.325" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.325" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.26</origin>

--- a/_inc/layouts/catacombgl.xml
+++ b/_inc/layouts/catacombgl.xml
@@ -12,7 +12,7 @@
 			<pos>0.475 0.335</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.18</origin>

--- a/_inc/layouts/cave.xml
+++ b/_inc/layouts/cave.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.01 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.01 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.43 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.43 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -43,7 +43,7 @@
 			<size if="${screen.ratio} == '4/3'">0.38 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.28 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -52,7 +52,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/cbm2.xml
+++ b/_inc/layouts/cbm2.xml
@@ -13,7 +13,7 @@
 			<maxSize>0.2</maxSize>
 			<rotation/>
 			<storyboard>
-				<animation property="pos" to="0.22 0.376" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.376" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.26</origin>

--- a/_inc/layouts/cdi.xml
+++ b/_inc/layouts/cdi.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.385</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.37</origin>

--- a/_inc/layouts/cgenie.xml
+++ b/_inc/layouts/cgenie.xml
@@ -12,7 +12,7 @@
 			<pos>0.48 0.352</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2 0.352" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2 0.352" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/cgenius.xml
+++ b/_inc/layouts/cgenius.xml
@@ -12,7 +12,7 @@
 			<pos>0.475 0.335</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.18</origin>

--- a/_inc/layouts/channelf.xml
+++ b/_inc/layouts/channelf.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/chihiro.xml
+++ b/_inc/layouts/chihiro.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.004 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.004 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.435 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.435 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.36 0.16</size>
 			<size if="${screen.ratio} == '21/9'">0.27 0.2</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.2</origin>

--- a/_inc/layouts/clonehero.xml
+++ b/_inc/layouts/clonehero.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.373</pos>
 			<maxSize>0.355</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.373" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.373" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.385</origin>

--- a/_inc/layouts/coco.xml
+++ b/_inc/layouts/coco.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.21 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.21 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/col-fallout.xml
+++ b/_inc/layouts/col-fallout.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2101 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2101 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/colecovision.xml
+++ b/_inc/layouts/colecovision.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/commanderx16.xml
+++ b/_inc/layouts/commanderx16.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.354</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.354" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.354" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/cpc464p.xml
+++ b/_inc/layouts/cpc464p.xml
@@ -13,7 +13,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.238</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/cplus4.xml
+++ b/_inc/layouts/cplus4.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.356</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.356" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.356" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.24</origin>

--- a/_inc/layouts/cps1.xml
+++ b/_inc/layouts/cps1.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/cps2.xml
+++ b/_inc/layouts/cps2.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/cps3.xml
+++ b/_inc/layouts/cps3.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/crvision.xml
+++ b/_inc/layouts/crvision.xml
@@ -13,7 +13,7 @@
 			<pos>0.48 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.20 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.20 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/custom-collections.xml
+++ b/_inc/layouts/custom-collections.xml
@@ -12,7 +12,7 @@
 			<path>./../../_inc/anim/custom-coll-fix.png</path>
 			<zIndex>26</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -27,7 +27,7 @@
 			<size if="${screen.ratio} == '4/3'">0.4 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.31 0.2</size>
 			<storyboard>
-				<animation property="pos" to="0.21 0.42" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.21 0.42" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -36,7 +36,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/daphne.xml
+++ b/_inc/layouts/daphne.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/darkforce.xml
+++ b/_inc/layouts/darkforce.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2101 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2101 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/datach.xml
+++ b/_inc/layouts/datach.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/dendy.xml
+++ b/_inc/layouts/dendy.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/devilutionx.xml
+++ b/_inc/layouts/devilutionx.xml
@@ -12,7 +12,7 @@
 			<pos>0.435 0.445</pos>
 			<maxSize>0.29</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.155 0.445" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.155 0.445" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/digiblst.xml
+++ b/_inc/layouts/digiblst.xml
@@ -11,7 +11,7 @@
 			<pos>0.505 0.493</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.225 0.493" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.225 0.493" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -21,7 +21,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.49</origin>

--- a/_inc/layouts/dos.xml
+++ b/_inc/layouts/dos.xml
@@ -12,7 +12,7 @@
 			<pos>0.475 0.335</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.18</origin>

--- a/_inc/layouts/dragon32.xml
+++ b/_inc/layouts/dragon32.xml
@@ -13,7 +13,7 @@
 			<pos>0.524 0.4</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.244 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.244 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.37</origin>

--- a/_inc/layouts/dreamcast-jp.xml
+++ b/_inc/layouts/dreamcast-jp.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.364</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.364" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.364" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/dreamcast.xml
+++ b/_inc/layouts/dreamcast.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.364</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.364" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.364" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/dxx-rebirth.xml
+++ b/_inc/layouts/dxx-rebirth.xml
@@ -13,7 +13,7 @@
 			<pos>0.54 0.45</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.234 0.43" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.234 0.43" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/easyrpg.xml
+++ b/_inc/layouts/easyrpg.xml
@@ -13,7 +13,7 @@
 			<pos>0.5 0.378</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.378" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.378" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/ecwolf.xml
+++ b/_inc/layouts/ecwolf.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.36</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.31</origin>

--- a/_inc/layouts/eduke32.xml
+++ b/_inc/layouts/eduke32.xml
@@ -12,7 +12,7 @@
 			<pos>0.432 0.45</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.152 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.152 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.455</origin>

--- a/_inc/layouts/electron.xml
+++ b/_inc/layouts/electron.xml
@@ -12,7 +12,7 @@
 			<pos>0.489 0.398</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.209 0.398" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.209 0.398" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.34</origin>

--- a/_inc/layouts/elektronika.xml
+++ b/_inc/layouts/elektronika.xml
@@ -13,7 +13,7 @@
 			<maxSize>0.265</maxSize>
 			<maxSize if="${screen.ratio} == '4/3'">0.28</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.465" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.465" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.46</origin>

--- a/_inc/layouts/ep128.xml
+++ b/_inc/layouts/ep128.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.335</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.25</origin>

--- a/_inc/layouts/etlegacy.xml
+++ b/_inc/layouts/etlegacy.xml
@@ -15,7 +15,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.31</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.209 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.209 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/exaarcadia.xml
+++ b/_inc/layouts/exaarcadia.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/exboard.xml
+++ b/_inc/layouts/exboard.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.005 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.005 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.43 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.43 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.29 0.2</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.435" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.435" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/exl100.xml
+++ b/_inc/layouts/exl100.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.355</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.355" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.355" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/fallout-ce.xml
+++ b/_inc/layouts/fallout-ce.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2101 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2101 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/famicom.xml
+++ b/_inc/layouts/famicom.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/fangames.xml
+++ b/_inc/layouts/fangames.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/fbneo.xml
+++ b/_inc/layouts/fbneo.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/fds.xml
+++ b/_inc/layouts/fds.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/fightcade.xml
+++ b/_inc/layouts/fightcade.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.618</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.514</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.462" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.462" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.47</origin>

--- a/_inc/layouts/flash.xml
+++ b/_inc/layouts/flash.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.393</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.42</origin>

--- a/_inc/layouts/fm7.xml
+++ b/_inc/layouts/fm7.xml
@@ -14,7 +14,7 @@
 			<maxSize>0.22</maxSize>
 			<maxSize if="${screen.ratio} == '4/3'">0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.189 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.189 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.28</origin>

--- a/_inc/layouts/fmtowns.xml
+++ b/_inc/layouts/fmtowns.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.335</pos>
 			<maxSize>0.257</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.29</origin>

--- a/_inc/layouts/fpinball.xml
+++ b/_inc/layouts/fpinball.xml
@@ -12,7 +12,7 @@
 			<pos>0.501 0.405</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.395</origin>

--- a/_inc/layouts/fury.xml
+++ b/_inc/layouts/fury.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2101 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2101 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/gaelco.xml
+++ b/_inc/layouts/gaelco.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/galaxy.xml
+++ b/_inc/layouts/galaxy.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.35</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.35" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.35" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.2</origin>

--- a/_inc/layouts/gamate.xml
+++ b/_inc/layouts/gamate.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.462</pos>
 			<maxSize>0.264</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.462" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.462" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/gameandwatch.xml
+++ b/_inc/layouts/gameandwatch.xml
@@ -13,7 +13,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.3</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.464" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.464" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/gamecom.xml
+++ b/_inc/layouts/gamecom.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.44</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.44" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.44" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.4</origin>

--- a/_inc/layouts/gamegear.xml
+++ b/_inc/layouts/gamegear.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.422</pos>
 			<maxSize>0.225</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.422" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.422" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/gameking3.xml
+++ b/_inc/layouts/gameking3.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.2</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.17</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.445" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.445" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/gamepock.xml
+++ b/_inc/layouts/gamepock.xml
@@ -13,7 +13,7 @@
 			<pos>0.482 0.444</pos>
 			<maxSize>0.216</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.202 0.444" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.202 0.444" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.4</origin>

--- a/_inc/layouts/gamewave.xml
+++ b/_inc/layouts/gamewave.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.364</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.364" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.364" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/gb-msu.xml
+++ b/_inc/layouts/gb-msu.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/gb.xml
+++ b/_inc/layouts/gb.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.35</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.35" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.35" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.243</origin>

--- a/_inc/layouts/gb2players.xml
+++ b/_inc/layouts/gb2players.xml
@@ -13,7 +13,7 @@
 			<pos>0.338 0.45</pos>
 			<maxSize>0.16</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.058 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.058 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-right" extra="true">
@@ -28,7 +28,7 @@
 			<maxSize>0.16</maxSize>
 			<rotation>180</rotation>
 			<storyboard>
-				<animation property="pos" to="0.38 0.54" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.38 0.54" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -36,7 +36,7 @@
 			<path>./../../_inc/anim/video/gb.mp4</path>
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gb.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.375</origin>
@@ -54,7 +54,7 @@
 			<path>./../../_inc/anim/video/gb.mp4</path>
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gb.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<audio>false</audio>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>

--- a/_inc/layouts/gb_top.xml
+++ b/_inc/layouts/gb_top.xml
@@ -13,7 +13,7 @@
 			<pos>0.645 0.32</pos>
 			<maxSize>0.225</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.365 0.32" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.365 0.32" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-left" extra="true">
@@ -27,7 +27,7 @@
 			<pos>0.352 0.35</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.072 0.35" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.072 0.35" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -37,7 +37,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gbc.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.215</origin>
@@ -58,7 +58,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/gb.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<audio>false</audio>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.24</origin>

--- a/_inc/layouts/gba.xml
+++ b/_inc/layouts/gba.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.32</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.465</origin>

--- a/_inc/layouts/gba2players.xml
+++ b/_inc/layouts/gba2players.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.21</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.17</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.249 0.755" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.249 0.755" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-right" extra="true">
@@ -30,7 +30,7 @@
 			<maxSize if="${screen.ratio} == '16/10'">0.17</maxSize>
 			<rotation>180</rotation>
 			<storyboard>
-				<animation property="pos" to="0.191 0.245" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.191 0.245" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -38,7 +38,7 @@
 			<path>./../../_inc/anim/video/gba.mp4</path>
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gba.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 1.1</origin>
@@ -57,7 +57,7 @@
 			<path>./../../_inc/anim/video/gba.mp4</path>
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gba.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<audio>false</audio>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>

--- a/_inc/layouts/gba_top.xml
+++ b/_inc/layouts/gba_top.xml
@@ -18,7 +18,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.32</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -28,7 +28,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.465</origin>

--- a/_inc/layouts/gbah.xml
+++ b/_inc/layouts/gbah.xml
@@ -18,7 +18,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.32</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -28,7 +28,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gba.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.465</origin>
@@ -44,7 +44,7 @@
 		</video>
 			<video name="videoglich" extra="true">
             <path>./../../_inc/anim/video/glich.mp4</path>
-            <delay>0</delay>
+            <delay>1</delay>
             <effect>none</effect>
  			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.465</origin>

--- a/_inc/layouts/gbc.xml
+++ b/_inc/layouts/gbc.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.32</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.32" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.32" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.214</origin>

--- a/_inc/layouts/gbc2players.xml
+++ b/_inc/layouts/gbc2players.xml
@@ -14,7 +14,7 @@
 			<maxSize>0.16</maxSize>
 			<rotation>180</rotation>
 			<storyboard>
-				<animation property="pos" to="0.04 0.62" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.04 0.62" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-right" extra="true">
@@ -28,7 +28,7 @@
 			<pos>0.68 0.38</pos>
 			<maxSize>0.16</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.40 0.38" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.40 0.38" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -36,7 +36,7 @@
 			<path>./../../_inc/anim/video/gbc.mp4</path>
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gbc.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<audio>false</audio>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
@@ -56,7 +56,7 @@
 			<path>./../../_inc/anim/video/gbc.mp4</path>
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gbc.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.19</origin>

--- a/_inc/layouts/gbch.xml
+++ b/_inc/layouts/gbch.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.32</pos>
 			<maxSize>0.225</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.32" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.32" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gbc.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.214</origin>
@@ -40,7 +40,7 @@
 		</video>
 		<video name="videoglich" extra="true">
             <path>./../../_inc/anim/video/glich.mp4</path>
-            <delay>0</delay>
+            <delay>1</delay>
             <effect>none</effect>
  			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.214</origin>

--- a/_inc/layouts/gbh.xml
+++ b/_inc/layouts/gbh.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.35</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.35" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.35" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gb.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.243</origin>
@@ -40,7 +40,7 @@
 		</video>
 			<video name="videoglich" extra="true">
 			<path>./../../_inc/anim/video/glich.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
  			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/gc-jp.xml
+++ b/_inc/layouts/gc-jp.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.367</pos>
 			<maxSize>0.284</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.367" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.367" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/gc.xml
+++ b/_inc/layouts/gc.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.367</pos>
 			<maxSize>0.284</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.367" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.367" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/gch.xml
+++ b/_inc/layouts/gch.xml
@@ -16,7 +16,7 @@
 			<pos>0.499 0.367</pos>
 			<maxSize>0.284</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.367" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.367" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/gc.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>
@@ -41,7 +41,7 @@
 		</video>
 		<video name="videoglich" extra="true">
 			<path>./../../_inc/anim/video/glich.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
  			<origin>0.5 0.5</origin>
 			<origin>0.5 0.5</origin>

--- a/_inc/layouts/gemrb.xml
+++ b/_inc/layouts/gemrb.xml
@@ -15,7 +15,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.249 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.249 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/genesis.xml
+++ b/_inc/layouts/genesis.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/genh.xml
+++ b/_inc/layouts/genh.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/megadrive.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>
@@ -39,7 +39,7 @@
 		</video>
 			<video name="videoglich" extra="true">
 			<path>./../../_inc/anim/video/glich.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
  			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/ggh.xml
+++ b/_inc/layouts/ggh.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.422</pos>
 			<maxSize>0.225</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.422" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.422" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/gamegear.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>
@@ -40,7 +40,7 @@
 		</video>
 			<video name="videoglich" extra="true">
             <path>./../../_inc/anim/video/glich.mp4</path>
-            <delay>0</delay>
+            <delay>1</delay>
             <effect>none</effect>
  			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/gmaster.xml
+++ b/_inc/layouts/gmaster.xml
@@ -12,7 +12,7 @@
 			<pos>0.501 0.47</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/gog.xml
+++ b/_inc/layouts/gog.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/windows.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/gp32.xml
+++ b/_inc/layouts/gp32.xml
@@ -10,7 +10,7 @@
 			<pos>0.5 0.495</pos>
 			<maxSize>0.342</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.495" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.495" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -20,7 +20,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.493</pos>

--- a/_inc/layouts/gx4000.xml
+++ b/_inc/layouts/gx4000.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.375</pos>
 			<maxSize>0.228</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.375" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.375" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/gzdoom.xml
+++ b/_inc/layouts/gzdoom.xml
@@ -13,7 +13,7 @@
 			<pos>0.541 0.447</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.261 0.447" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.261 0.447" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.42</origin>

--- a/_inc/layouts/hbmame.xml
+++ b/_inc/layouts/hbmame.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/hec2hr.xml
+++ b/_inc/layouts/hec2hr.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.335</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.25</origin>

--- a/_inc/layouts/hikaru.xml
+++ b/_inc/layouts/hikaru.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.005 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.005 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.43 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.43 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.29 0.2</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.435" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.435" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/hyperscan.xml
+++ b/_inc/layouts/hyperscan.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.31</origin>

--- a/_inc/layouts/ibmpcjr.xml
+++ b/_inc/layouts/ibmpcjr.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.354</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.354" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.354" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.23</origin>

--- a/_inc/layouts/igspgm.xml
+++ b/_inc/layouts/igspgm.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.007 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.007 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.433 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.433 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -44,7 +44,7 @@
 			<size if="${screen.ratio} == '16/10'">0.39 0.22</size>
 			<size if="${screen.ratio} == '21/9'">0.28 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -53,7 +53,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/igtslots.xml
+++ b/_inc/layouts/igtslots.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.375 0.57" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.375 0.57" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -30,7 +30,7 @@
 			<size if="${screen.ratio} == '16/10'">0.206 0.09</size>
 			<size if="${screen.ratio} == '21/9'">0.16 0.1</size>
 			<storyboard>
-				<animation property="pos" to="0.229 0.6" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.229 0.6" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -40,7 +40,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.8</origin>

--- a/_inc/layouts/ikemen.xml
+++ b/_inc/layouts/ikemen.xml
@@ -15,7 +15,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.42</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.35</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.382" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.382" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.55 0.36</origin>

--- a/_inc/layouts/intellivision.xml
+++ b/_inc/layouts/intellivision.xml
@@ -13,7 +13,7 @@
 			<pos>0.48 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.20 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.20 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/ioquake3.xml
+++ b/_inc/layouts/ioquake3.xml
@@ -13,7 +13,7 @@
 			<pos>0.4485 0.457</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.1685 0.457" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.1685 0.457" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/iortcw.xml
+++ b/_inc/layouts/iortcw.xml
@@ -15,7 +15,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.249 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.249 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/iqueplayer.xml
+++ b/_inc/layouts/iqueplayer.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/j2me.xml
+++ b/_inc/layouts/j2me.xml
@@ -12,7 +12,7 @@
 			<pos>0.497 0.42</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.217 0.42" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.217 0.42" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/jupace.xml
+++ b/_inc/layouts/jupace.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/konamilcd.xml
+++ b/_inc/layouts/konamilcd.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.15</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/konamipc.xml
+++ b/_inc/layouts/konamipc.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/laser310.xml
+++ b/_inc/layouts/laser310.xml
@@ -13,7 +13,7 @@
 			<pos>0.4645 0.41</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.1845 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.1845 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/laseractive.xml
+++ b/_inc/layouts/laseractive.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/lcdgames.xml
+++ b/_inc/layouts/lcdgames.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.45</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.43</origin>

--- a/_inc/layouts/lightgun.xml
+++ b/_inc/layouts/lightgun.xml
@@ -13,7 +13,7 @@
 			<size>0.39 0.16</size>
 			<size if="${screen.ratio} == '21/9'">0.295 0.16</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/lindbergh.xml
+++ b/_inc/layouts/lindbergh.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/locomalito.xml
+++ b/_inc/layouts/locomalito.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/loopy.xml
+++ b/_inc/layouts/loopy.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.385</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.37</origin>

--- a/_inc/layouts/lowresnx.xml
+++ b/_inc/layouts/lowresnx.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.44</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.44" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.44" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.42</origin>

--- a/_inc/layouts/lutro.xml
+++ b/_inc/layouts/lutro.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.374</pos>
 			<maxSize>0.295</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.374" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.374" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.34</origin>

--- a/_inc/layouts/m21.xml
+++ b/_inc/layouts/m21.xml
@@ -13,7 +13,7 @@
 			<pos>0.474 0.365</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.194 0.365" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.194 0.365" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/m5.xml
+++ b/_inc/layouts/m5.xml
@@ -13,7 +13,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/macintosh.xml
+++ b/_inc/layouts/macintosh.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.375</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.375" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.375" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/makecode.xml
+++ b/_inc/layouts/makecode.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.405</pos>
 			<maxSize>0.2</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/mame.xml
+++ b/_inc/layouts/mame.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/mark3.xml
+++ b/_inc/layouts/mark3.xml
@@ -13,7 +13,7 @@
 			<pos>0.475 0.39</pos>
 			<maxSize>0.242</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/mastersystem.xml
+++ b/_inc/layouts/mastersystem.xml
@@ -13,7 +13,7 @@
 			<pos>0.475 0.39</pos>
 			<maxSize>0.242</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/max.xml
+++ b/_inc/layouts/max.xml
@@ -13,7 +13,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.28</origin>

--- a/_inc/layouts/mbee.xml
+++ b/_inc/layouts/mbee.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.41</pos>
 			<maxSize>0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/megacd.xml
+++ b/_inc/layouts/megacd.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/megacd32x.xml
+++ b/_inc/layouts/megacd32x.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/megadrive-jp.xml
+++ b/_inc/layouts/megadrive-jp.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/megadrive.xml
+++ b/_inc/layouts/megadrive.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/megadrive_top.xml
+++ b/_inc/layouts/megadrive_top.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/megaduck.xml
+++ b/_inc/layouts/megaduck.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.35</pos>
 			<maxSize>0.215</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.35" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.35" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/microvsn.xml
+++ b/_inc/layouts/microvsn.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.44</pos>
 			<maxSize>0.125</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.44" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.44" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/model1.xml
+++ b/_inc/layouts/model1.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/model2.xml
+++ b/_inc/layouts/model2.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.007 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.007 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.433 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.433 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -44,7 +44,7 @@
 			<size if="${screen.ratio} == '16/10'">0.39 0.22</size>
 			<size if="${screen.ratio} == '21/9'">0.28 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -53,7 +53,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/model3.xml
+++ b/_inc/layouts/model3.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.005 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.005 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.43 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.43 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.29 0.2</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.435" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.435" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/mononcol.xml
+++ b/_inc/layouts/mononcol.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.255</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/moonlight.xml
+++ b/_inc/layouts/moonlight.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.497</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.417</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.392" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.392" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.405</origin>

--- a/_inc/layouts/mpu1000.xml
+++ b/_inc/layouts/mpu1000.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.235</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/msu-md.xml
+++ b/_inc/layouts/msu-md.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/msx.xml
+++ b/_inc/layouts/msx.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.358</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.358" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.358" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/msx2+.xml
+++ b/_inc/layouts/msx2+.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.335</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.26</origin>

--- a/_inc/layouts/msx2.xml
+++ b/_inc/layouts/msx2.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.358</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.358" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.358" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/msxlaserdisk.xml
+++ b/_inc/layouts/msxlaserdisk.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.26</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.26" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.26" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.13</origin>

--- a/_inc/layouts/msxturbor.xml
+++ b/_inc/layouts/msxturbor.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.358</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.358" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.358" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/mtx512.xml
+++ b/_inc/layouts/mtx512.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.325</pos>
 			<maxSize>0.275</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.325" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.325" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/mugen.xml
+++ b/_inc/layouts/mugen.xml
@@ -15,7 +15,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.41</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.345</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.384" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.384" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.365</origin>

--- a/_inc/layouts/multivision.xml
+++ b/_inc/layouts/multivision.xml
@@ -13,7 +13,7 @@
 			<pos>0.48 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.20 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.20 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/myvision.xml
+++ b/_inc/layouts/myvision.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/mz2500.xml
+++ b/_inc/layouts/mz2500.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.354</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.354" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.354" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/n501.xml
+++ b/_inc/layouts/n501.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.367</pos>
 			<maxSize>0.284</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.367" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.367" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/n64-jp.xml
+++ b/_inc/layouts/n64-jp.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/n64.xml
+++ b/_inc/layouts/n64.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/n64_top.xml
+++ b/_inc/layouts/n64_top.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/n64.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/n64dd.xml
+++ b/_inc/layouts/n64dd.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.31</origin>

--- a/_inc/layouts/n64h.xml
+++ b/_inc/layouts/n64h.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.33</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/n64.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>
@@ -41,7 +41,7 @@
 		</video>
 		 <video name="videoglich" extra="true">
 			<path>./../../_inc/anim/video/glich.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
  			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/namco11.xml
+++ b/_inc/layouts/namco11.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/namco12.xml
+++ b/_inc/layouts/namco12.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.165</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.165</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.37" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.37" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.25</origin>

--- a/_inc/layouts/namco22.xml
+++ b/_inc/layouts/namco22.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/namco2x6.xml
+++ b/_inc/layouts/namco2x6.xml
@@ -13,7 +13,7 @@
 			<size>0.39 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.295 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.18</origin>

--- a/_inc/layouts/namcoes3.xml
+++ b/_inc/layouts/namcoes3.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/naomi.xml
+++ b/_inc/layouts/naomi.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.01 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.01 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.432 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.432 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.36 0.16</size>
 			<size if="${screen.ratio} == '21/9'">0.27 0.2</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.375" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.375" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.2</origin>

--- a/_inc/layouts/naomi2.xml
+++ b/_inc/layouts/naomi2.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.01 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.01 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.432 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.432 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.36 0.16</size>
 			<size if="${screen.ratio} == '21/9'">0.27 0.2</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.375" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.375" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.2</origin>

--- a/_inc/layouts/nds.xml
+++ b/_inc/layouts/nds.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.47</pos>
 			<maxSize>0.61</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>

--- a/_inc/layouts/neogeo.xml
+++ b/_inc/layouts/neogeo.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.355</pos>
 			<maxSize>0.256</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.355" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.355" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/neogeo64.xml
+++ b/_inc/layouts/neogeo64.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.007 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.007 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.433 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.433 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -44,7 +44,7 @@
 			<size if="${screen.ratio} == '16/10'">0.39 0.22</size>
 			<size if="${screen.ratio} == '21/9'">0.28 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -53,7 +53,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/neogeocd.xml
+++ b/_inc/layouts/neogeocd.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.355</pos>
 			<maxSize>0.256</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.355" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.355" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/neogeomvs.xml
+++ b/_inc/layouts/neogeomvs.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/nes-msu.xml
+++ b/_inc/layouts/nes-msu.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/nes.xml
+++ b/_inc/layouts/nes.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/nes_aladdin.xml
+++ b/_inc/layouts/nes_aladdin.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/nes_hd.xml
+++ b/_inc/layouts/nes_hd.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.31</origin>

--- a/_inc/layouts/nes_top.xml
+++ b/_inc/layouts/nes_top.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/nesh.xml
+++ b/_inc/layouts/nesh.xml
@@ -16,7 +16,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.21 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.21 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/nes.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin>0.5 0.5</origin>
@@ -42,7 +42,7 @@
 		</video>
 			<video name="videoglich" extra="true">
             <path>./../../_inc/anim/video/glich.mp4</path>
-            <delay>0</delay>
+            <delay>1</delay>
             <effect>none</effect>
  			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/nesicax.xml
+++ b/_inc/layouts/nesicax.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/nesicax2.xml
+++ b/_inc/layouts/nesicax2.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/ngage.xml
+++ b/_inc/layouts/ngage.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.477</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.477" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.477" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.47</origin>

--- a/_inc/layouts/ngp.xml
+++ b/_inc/layouts/ngp.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.455</pos>
 			<maxSize>0.33</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.455" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.455" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/ngpc.xml
+++ b/_inc/layouts/ngpc.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.468</pos>
 			<maxSize>0.332</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.468" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.468" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.47</origin>

--- a/_inc/layouts/nomad.xml
+++ b/_inc/layouts/nomad.xml
@@ -10,7 +10,7 @@
 			<pos>0.496 0.49</pos>
 			<maxSize>0.225</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.216 0.49" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.216 0.49" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -20,7 +20,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/megadrive.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.496 0.49</pos>

--- a/_inc/layouts/odyssey2.xml
+++ b/_inc/layouts/odyssey2.xml
@@ -13,7 +13,7 @@
 			<pos>0.48 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.20 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.20 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/ondra.xml
+++ b/_inc/layouts/ondra.xml
@@ -12,7 +12,7 @@
 			<pos>0.501 0.363</pos>
 			<maxSize>0.232</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.285</origin>

--- a/_inc/layouts/openbor.xml
+++ b/_inc/layouts/openbor.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.364</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.364" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.364" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/opengoal.xml
+++ b/_inc/layouts/opengoal.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/openjk.xml
+++ b/_inc/layouts/openjk.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2101 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2101 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/openlara.xml
+++ b/_inc/layouts/openlara.xml
@@ -13,7 +13,7 @@
 			<pos>0.449 0.457</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.169 0.457" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.169 0.457" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/orao.xml
+++ b/_inc/layouts/orao.xml
@@ -12,7 +12,7 @@
 			<pos>0.501 0.363</pos>
 			<maxSize>0.232</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.285</origin>

--- a/_inc/layouts/oricatmos.xml
+++ b/_inc/layouts/oricatmos.xml
@@ -13,7 +13,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.235</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.21 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.21 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.49 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/p2000t.xml
+++ b/_inc/layouts/p2000t.xml
@@ -13,7 +13,7 @@
 			<pos>0.44 0.36</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.16 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.16 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/odyssey2.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/palm.xml
+++ b/_inc/layouts/palm.xml
@@ -13,7 +13,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.48</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.39</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.222 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.222 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.47</origin>

--- a/_inc/layouts/pc88.xml
+++ b/_inc/layouts/pc88.xml
@@ -14,7 +14,7 @@
 			<rotation>-1</rotation>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.171 0.368" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.171 0.368" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/pc98.xml
+++ b/_inc/layouts/pc98.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.365</pos>
 			<maxSize>0.20</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.21 0.365" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.21 0.365" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/pce-cd.xml
+++ b/_inc/layouts/pce-cd.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.395</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.395" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.395" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.34</origin>

--- a/_inc/layouts/pcengine.xml
+++ b/_inc/layouts/pcengine.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.415</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.415" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.415" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/pcfx.xml
+++ b/_inc/layouts/pcfx.xml
@@ -13,7 +13,7 @@
 			<pos>0.441 0.335</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.161 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.161 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/pcvr.xml
+++ b/_inc/layouts/pcvr.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/pdark.xml
+++ b/_inc/layouts/pdark.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.497</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.417</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.394" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.394" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.405</origin>

--- a/_inc/layouts/pdp1.xml
+++ b/_inc/layouts/pdp1.xml
@@ -12,7 +12,7 @@
 			<pos>0.393 0.455</pos>
 			<maxSize>0.275</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.113 0.455" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.113 0.455" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/pecom64.xml
+++ b/_inc/layouts/pecom64.xml
@@ -11,7 +11,7 @@
 			<pos>0.502 0.403</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.222 0.403" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.222 0.403" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/pegasus.xml
+++ b/_inc/layouts/pegasus.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/pet.xml
+++ b/_inc/layouts/pet.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.297</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.297" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.297" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.2</origin>

--- a/_inc/layouts/pico.xml
+++ b/_inc/layouts/pico.xml
@@ -13,7 +13,7 @@
 			<pos>0.422 0.382</pos>
 			<maxSize>0.252</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.142 0.382" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.142 0.382" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/pico8.xml
+++ b/_inc/layouts/pico8.xml
@@ -12,7 +12,7 @@
 			<pos>0.501 0.345</pos>
 			<maxSize>0.3</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.345" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.345" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.31</origin>

--- a/_inc/layouts/pinballfx.xml
+++ b/_inc/layouts/pinballfx.xml
@@ -16,7 +16,7 @@
 			<pos>0.501 0.405</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/fpinball.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.395</origin>

--- a/_inc/layouts/pinballfx2.xml
+++ b/_inc/layouts/pinballfx2.xml
@@ -16,7 +16,7 @@
 			<pos>0.501 0.405</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/fpinball.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.395</origin>

--- a/_inc/layouts/pinballfx3.xml
+++ b/_inc/layouts/pinballfx3.xml
@@ -16,7 +16,7 @@
 			<pos>0.501 0.405</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/fpinball.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.395</origin>

--- a/_inc/layouts/pinballm.xml
+++ b/_inc/layouts/pinballm.xml
@@ -16,7 +16,7 @@
 			<pos>0.501 0.405</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/fpinball.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.395</origin>

--- a/_inc/layouts/pippin.xml
+++ b/_inc/layouts/pippin.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.364</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.364" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.364" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/plugnplay.xml
+++ b/_inc/layouts/plugnplay.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.364</pos>
 			<maxSize>0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.364" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.364" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/pocketchallengev2.xml
+++ b/_inc/layouts/pocketchallengev2.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.35</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.29</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.488" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.488" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../_inc/anim/video/${synonym}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>

--- a/_inc/layouts/pocketstation.xml
+++ b/_inc/layouts/pocketstation.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.37</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.37" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.37" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/pokemini.xml
+++ b/_inc/layouts/pokemini.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.4</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.31</origin>

--- a/_inc/layouts/ports.xml
+++ b/_inc/layouts/ports.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/prboom.xml
+++ b/_inc/layouts/prboom.xml
@@ -13,7 +13,7 @@
 			<pos>0.515 0.43</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.235 0.43" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.235 0.43" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.4</origin>

--- a/_inc/layouts/ps2-jp.xml
+++ b/_inc/layouts/ps2-jp.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.367</pos>
 			<maxSize>0.284</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.367" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.367" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/ps2.xml
+++ b/_inc/layouts/ps2.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.367</pos>
 			<maxSize>0.284</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.367" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.367" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/ps2h.xml
+++ b/_inc/layouts/ps2h.xml
@@ -16,7 +16,7 @@
 			<pos>0.499 0.367</pos>
 			<maxSize>0.284</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.367" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.367" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/ps3.xml
+++ b/_inc/layouts/ps3.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.5</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.4</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.347" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.347" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/ps3h.xml
+++ b/_inc/layouts/ps3h.xml
@@ -18,7 +18,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.5</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.4</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.347" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.347" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -28,7 +28,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/ps4.xml
+++ b/_inc/layouts/ps4.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.62</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.513</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.3978" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.3978" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.425</origin>

--- a/_inc/layouts/ps5.xml
+++ b/_inc/layouts/ps5.xml
@@ -15,7 +15,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.616</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.513</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.255 0.479" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.255 0.479" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.485</origin>

--- a/_inc/layouts/psp.xml
+++ b/_inc/layouts/psp.xml
@@ -12,7 +12,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.4</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.32</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.488" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.488" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.485</origin>

--- a/_inc/layouts/pspminis.xml
+++ b/_inc/layouts/pspminis.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.39</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.325</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.377" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.377" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.356</origin>

--- a/_inc/layouts/psvita.xml
+++ b/_inc/layouts/psvita.xml
@@ -12,7 +12,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.44</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.36</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.4935" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.4935" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.495</origin>

--- a/_inc/layouts/psx-jp.xml
+++ b/_inc/layouts/psx-jp.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.37</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.37" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.37" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/psx.xml
+++ b/_inc/layouts/psx.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.37</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.37" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.37" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/psxh.xml
+++ b/_inc/layouts/psxh.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.37</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.37" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.37" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/pv1000.xml
+++ b/_inc/layouts/pv1000.xml
@@ -13,7 +13,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/pv2000.xml
+++ b/_inc/layouts/pv2000.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.357</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.357" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.357" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.28</origin>

--- a/_inc/layouts/pygame.xml
+++ b/_inc/layouts/pygame.xml
@@ -12,7 +12,7 @@
 			<pos>0.497 0.483</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.217 0.483" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.217 0.483" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>

--- a/_inc/layouts/pyxel.xml
+++ b/_inc/layouts/pyxel.xml
@@ -12,7 +12,7 @@
 			<pos>0.503 0.452</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.223 0.452" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.223 0.452" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.4</origin>

--- a/_inc/layouts/quake.xml
+++ b/_inc/layouts/quake.xml
@@ -17,7 +17,7 @@
 			<pos>0.4485 0.457</pos>
 			<maxSize>0.268</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.1685 0.457" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.1685 0.457" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -28,7 +28,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/tyrquake.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/rawthrills.xml
+++ b/_inc/layouts/rawthrills.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/raze.xml
+++ b/_inc/layouts/raze.xml
@@ -13,7 +13,7 @@
 			<pos>0.449 0.4565</pos>
 			<maxSize>0.268</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.169 0.4565" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.169 0.4565" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/realrtcw.xml
+++ b/_inc/layouts/realrtcw.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.37</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.309</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.249 0.461" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.249 0.461" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/recordings.xml
+++ b/_inc/layouts/recordings.xml
@@ -5,7 +5,7 @@
 		<video name="videobox" extra="true">
 			<path>{random}</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.52 0.4</origin>

--- a/_inc/layouts/rott.xml
+++ b/_inc/layouts/rott.xml
@@ -13,7 +13,7 @@
 			<pos>0.54 0.45</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.234 0.43" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.234 0.43" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/rx78.xml
+++ b/_inc/layouts/rx78.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.358</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.358" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.358" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/samcoupe.xml
+++ b/_inc/layouts/samcoupe.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.365</pos>
 			<maxSize>0.225</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.365" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.365" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/satellaview.xml
+++ b/_inc/layouts/satellaview.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.39</pos>
 			<maxSize>0.28</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/saturn-jp.xml
+++ b/_inc/layouts/saturn-jp.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.364</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.364" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.364" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/saturn.xml
+++ b/_inc/layouts/saturn.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.364</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.364" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.364" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/sc-3000.xml
+++ b/_inc/layouts/sc-3000.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.34</pos>
 			<maxSize>0.235</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.34" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.34" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/scummvm.xml
+++ b/_inc/layouts/scummvm.xml
@@ -12,7 +12,7 @@
 			<pos>0.516 0.308</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.236 0.308" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.236 0.308" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.29</origin>

--- a/_inc/layouts/scv.xml
+++ b/_inc/layouts/scv.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/sega32x.xml
+++ b/_inc/layouts/sega32x.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.375</pos>
 			<maxSize>0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.375" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.375" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.34</origin>

--- a/_inc/layouts/segaai.xml
+++ b/_inc/layouts/segaai.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.36</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.209 0.398" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.209 0.398" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.34</origin>

--- a/_inc/layouts/segaalls.xml
+++ b/_inc/layouts/segaalls.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/segacd.xml
+++ b/_inc/layouts/segacd.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.375</pos>
 			<maxSize>0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.375" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.375" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.34</origin>

--- a/_inc/layouts/segacd32x.xml
+++ b/_inc/layouts/segacd32x.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.375</pos>
 			<maxSize>0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.375" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.375" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.34</origin>

--- a/_inc/layouts/segaer.xml
+++ b/_inc/layouts/segaer.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/segare.xml
+++ b/_inc/layouts/segare.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/segarw.xml
+++ b/_inc/layouts/segarw.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/segastv.xml
+++ b/_inc/layouts/segastv.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.007 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.007 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.433 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.433 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -44,7 +44,7 @@
 			<size if="${screen.ratio} == '16/10'">0.39 0.22</size>
 			<size if="${screen.ratio} == '21/9'">0.28 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -53,7 +53,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/segasystem32.xml
+++ b/_inc/layouts/segasystem32.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/sfc.xml
+++ b/_inc/layouts/sfc.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/sg-1000.xml
+++ b/_inc/layouts/sg-1000.xml
@@ -13,7 +13,7 @@
 			<pos>0.48 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.20 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.20 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/sgb.xml
+++ b/_inc/layouts/sgb.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/singe.xml
+++ b/_inc/layouts/singe.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/smc777.xml
+++ b/_inc/layouts/smc777.xml
@@ -12,7 +12,7 @@
 			<pos>0.502 0.36</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.222 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.222 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/snes-msu1.xml
+++ b/_inc/layouts/snes-msu1.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/snes.xml
+++ b/_inc/layouts/snes.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/snes_new.xml
+++ b/_inc/layouts/snes_new.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.5</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.4</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.347" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.347" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../_inc/anim/video/${synonym}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/snes_top.xml
+++ b/_inc/layouts/snes_top.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/snescd.xml
+++ b/_inc/layouts/snescd.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/snesh.xml
+++ b/_inc/layouts/snesh.xml
@@ -16,7 +16,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/snotec.xml
+++ b/_inc/layouts/snotec.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.18</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.16</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.393" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.393" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.2</origin>

--- a/_inc/layouts/socrates.xml
+++ b/_inc/layouts/socrates.xml
@@ -13,7 +13,7 @@
 			<pos>0.47 0.39</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.19 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.19 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/soh.xml
+++ b/_inc/layouts/soh.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/solarus.xml
+++ b/_inc/layouts/solarus.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.38</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.32</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.49</origin>

--- a/_inc/layouts/sonicretro.xml
+++ b/_inc/layouts/sonicretro.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.43</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.43" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.43" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.39</origin>

--- a/_inc/layouts/sorcerer.xml
+++ b/_inc/layouts/sorcerer.xml
@@ -13,7 +13,7 @@
 			<pos>0.4333 0.378</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.1533 0.378" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.1533 0.378" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/spectravideo.xml
+++ b/_inc/layouts/spectravideo.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/starship.xml
+++ b/_inc/layouts/starship.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/steam.xml
+++ b/_inc/layouts/steam.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.39</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.33</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.4763" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.4763" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.47</origin>

--- a/_inc/layouts/studio2.xml
+++ b/_inc/layouts/studio2.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/sufami.xml
+++ b/_inc/layouts/sufami.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/supercharger.xml
+++ b/_inc/layouts/supercharger.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/supergrafx.xml
+++ b/_inc/layouts/supergrafx.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.395</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.395" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.395" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.34</origin>

--- a/_inc/layouts/supervision.xml
+++ b/_inc/layouts/supervision.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.333</pos>
 			<maxSize>0.235</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.333" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.333" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.25</origin>

--- a/_inc/layouts/supracan.xml
+++ b/_inc/layouts/supracan.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/sv8000.xml
+++ b/_inc/layouts/sv8000.xml
@@ -13,7 +13,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/switch.xml
+++ b/_inc/layouts/switch.xml
@@ -12,7 +12,7 @@
 			<path>./../../_inc/anim/switch-fix.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -26,7 +26,7 @@
 			<size if="${screen.ratio} == '16/10'">0.55 0.6</size>
 			<size if="${screen.ratio} == '21/9'">0.4 0.75</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -35,7 +35,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.485</origin>

--- a/_inc/layouts/sys80.xml
+++ b/_inc/layouts/sys80.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.36</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.21 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.21 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/systemsp.xml
+++ b/_inc/layouts/systemsp.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.007 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.007 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.433 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.433 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -44,7 +44,7 @@
 			<size if="${screen.ratio} == '16/10'">0.39 0.22</size>
 			<size if="${screen.ratio} == '21/9'">0.28 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -53,7 +53,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/tduo.xml
+++ b/_inc/layouts/tduo.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.395</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.395" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.395" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/pce-cd.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/teknoparrot.xml
+++ b/_inc/layouts/teknoparrot.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/tg-cd.xml
+++ b/_inc/layouts/tg-cd.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.395</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.395" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.395" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/pce-cd.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/tg16.xml
+++ b/_inc/layouts/tg16.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.395</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.395" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.395" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/pcengine.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.33</origin>

--- a/_inc/layouts/thextech.xml
+++ b/_inc/layouts/thextech.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/thomson.xml
+++ b/_inc/layouts/thomson.xml
@@ -13,7 +13,7 @@
 			<pos>0.4755 0.39</pos>
 			<maxSize>0.257</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.1955 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.1955 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/ti99.xml
+++ b/_inc/layouts/ti99.xml
@@ -13,7 +13,7 @@
 			<pos>0.46 0.37</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.18 0.37" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.18 0.37" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.31</origin>

--- a/_inc/layouts/tic80.xml
+++ b/_inc/layouts/tic80.xml
@@ -12,7 +12,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.38</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.32</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.5</pos>

--- a/_inc/layouts/tiger.xml
+++ b/_inc/layouts/tiger.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.47</pos>
 			<maxSize>0.21</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.42</origin>

--- a/_inc/layouts/triforce.xml
+++ b/_inc/layouts/triforce.xml
@@ -15,7 +15,7 @@
 			<size if="${screen.ratio} == '4/3'">0.316 0.16</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.2</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.409" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.409" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -24,7 +24,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.32</origin>

--- a/_inc/layouts/tutor.xml
+++ b/_inc/layouts/tutor.xml
@@ -13,7 +13,7 @@
 			<pos>0.475 0.39</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/tvc64.xml
+++ b/_inc/layouts/tvc64.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.34</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.34" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.34" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/typex.xml
+++ b/_inc/layouts/typex.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/typex2.xml
+++ b/_inc/layouts/typex2.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/tyrquake.xml
+++ b/_inc/layouts/tyrquake.xml
@@ -13,7 +13,7 @@
 			<pos>0.4485 0.457</pos>
 			<maxSize>0.268</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.1685 0.457" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.1685 0.457" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/unis.xml
+++ b/_inc/layouts/unis.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/uzebox.xml
+++ b/_inc/layouts/uzebox.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.387</pos>
 			<maxSize>0.254</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.387" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.387" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/vc4000.xml
+++ b/_inc/layouts/vc4000.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.215</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/vectrex.xml
+++ b/_inc/layouts/vectrex.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.412</pos>
 			<maxSize>0.33</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.412" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.412" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.4</origin>

--- a/_inc/layouts/vemulator.xml
+++ b/_inc/layouts/vemulator.xml
@@ -10,7 +10,7 @@
 			<pos>0.5 0.5</pos>
 			<maxSize>0.16</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -21,7 +21,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.5</pos>

--- a/_inc/layouts/vg5k.xml
+++ b/_inc/layouts/vg5k.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.335</pos>
 			<maxSize>0.23</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.335" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.335" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.25</origin>

--- a/_inc/layouts/vgm.xml
+++ b/_inc/layouts/vgm.xml
@@ -14,7 +14,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.14" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.14" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -29,7 +29,7 @@
 			<path>./../../_inc/images/space169.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.218 0.7" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.7" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -44,7 +44,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.59</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.492</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.425" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.425" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -55,7 +55,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/vidbrain.xml
+++ b/_inc/layouts/vidbrain.xml
@@ -13,7 +13,7 @@
 			<pos>0.4815 0.402</pos>
 			<maxSize>0.215</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2015 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2015 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.36</origin>

--- a/_inc/layouts/videodriver.xml
+++ b/_inc/layouts/videodriver.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.348</pos>
 			<maxSize>0.29</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.348" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.348" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/videopac.xml
+++ b/_inc/layouts/videopac.xml
@@ -13,7 +13,7 @@
 			<pos>0.48 0.4</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.20 0.4" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.20 0.4" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/videopacplus.xml
+++ b/_inc/layouts/videopacplus.xml
@@ -13,7 +13,7 @@
 			<pos>0.443 0.39</pos>
 			<maxSize>0.24</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.163 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.163 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/vii.xml
+++ b/_inc/layouts/vii.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.49</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.41</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.394</origin>

--- a/_inc/layouts/vircon32.xml
+++ b/_inc/layouts/vircon32.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.5</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.4</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.347" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.347" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../_inc/anim/video/${synonym}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/virtualboy.xml
+++ b/_inc/layouts/virtualboy.xml
@@ -13,7 +13,7 @@
 			<maxSize>0.16</maxSize>
 			<maxSize if="${screen.ratio} == '4/3'">0.19</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.22" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.22" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 -0.15</origin>

--- a/_inc/layouts/vis.xml
+++ b/_inc/layouts/vis.xml
@@ -12,7 +12,7 @@
 			<pos>0.499 0.39</pos>
 			<maxSize>0.255</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/vitaquake2.xml
+++ b/_inc/layouts/vitaquake2.xml
@@ -13,7 +13,7 @@
 			<pos>0.45 0.457</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.17 0.457" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.17 0.457" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/vpinball.xml
+++ b/_inc/layouts/vpinball.xml
@@ -16,7 +16,7 @@
 			<pos>0.501 0.405</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/fpinball.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.395</origin>

--- a/_inc/layouts/vsmile.xml
+++ b/_inc/layouts/vsmile.xml
@@ -12,7 +12,7 @@
 			<pos>0.4995 0.3895</pos>
 			<maxSize>0.28</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.2195 0.3895" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.2195 0.3895" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/wahlap.xml
+++ b/_inc/layouts/wahlap.xml
@@ -13,7 +13,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.025 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.025 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-right" extra="true">
@@ -27,7 +27,7 @@
 			<path>./../../_inc/images/space.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.415 0.45" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.415 0.45" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video-arcade" extra="true">
@@ -42,7 +42,7 @@
 			<size if="${screen.ratio} == '4/3'">0.31 0.17</size>
 			<size if="${screen.ratio} == '21/9'">0.24 0.22</size>
 			<storyboard>
-				<animation property="pos" to="0.219 0.47" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.47" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -51,7 +51,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/wasm4.xml
+++ b/_inc/layouts/wasm4.xml
@@ -12,7 +12,7 @@
 			<pos>0.50 0.365</pos>
 			<maxSize>0.32</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.365" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.365" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/wii.xml
+++ b/_inc/layouts/wii.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.49</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.41</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.394</origin>

--- a/_inc/layouts/wiih.xml
+++ b/_inc/layouts/wiih.xml
@@ -18,7 +18,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.49</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.41</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -29,7 +29,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.394</origin>

--- a/_inc/layouts/wiiu-sky.xml
+++ b/_inc/layouts/wiiu-sky.xml
@@ -12,7 +12,7 @@
 			<path>./../../_inc/anim/wiiu-fix.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -26,7 +26,7 @@
 			<size if="${screen.ratio} == '16/10'">0.55 0.6</size>
 			<size if="${screen.ratio} == '21/9'">0.4 0.75</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -35,7 +35,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '21/9'">0.5 0.502</origin>

--- a/_inc/layouts/wiiu.xml
+++ b/_inc/layouts/wiiu.xml
@@ -12,7 +12,7 @@
 			<path>./../../_inc/anim/wiiu-fix.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -26,7 +26,7 @@
 			<size if="${screen.ratio} == '16/10'">0.55 0.6</size>
 			<size if="${screen.ratio} == '21/9'">0.4 0.75</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -35,7 +35,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '21/9'">0.5 0.502</origin>

--- a/_inc/layouts/wiiueshop.xml
+++ b/_inc/layouts/wiiueshop.xml
@@ -12,7 +12,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.35</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.292</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.495" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.495" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.495</pos>

--- a/_inc/layouts/wiiware.xml
+++ b/_inc/layouts/wiiware.xml
@@ -12,7 +12,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.35</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.292</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.495" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.495" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<pos>0.5 0.495</pos>

--- a/_inc/layouts/win11.xml
+++ b/_inc/layouts/win11.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.497</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.417</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.394" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.394" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/moonlight.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.405</origin>

--- a/_inc/layouts/win311.xml
+++ b/_inc/layouts/win311.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.36</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.36" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.36" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3</origin>

--- a/_inc/layouts/win95.xml
+++ b/_inc/layouts/win95.xml
@@ -13,7 +13,7 @@
 			<pos>0.514 0.43</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.234 0.43" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.234 0.43" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/win98.xml
+++ b/_inc/layouts/win98.xml
@@ -13,7 +13,7 @@
 			<pos>0.462 0.43</pos>
 			<maxSize>0.22</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.182 0.43" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.182 0.43" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.38</origin>

--- a/_inc/layouts/winbigfish.xml
+++ b/_inc/layouts/winbigfish.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/windows.xml
+++ b/_inc/layouts/windows.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/wingamehouse.xml
+++ b/_inc/layouts/wingamehouse.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/wingog.xml
+++ b/_inc/layouts/wingog.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/windows.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/winpopcap.xml
+++ b/_inc/layouts/winpopcap.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.473</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.3925</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.41" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.41" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.41</origin>

--- a/_inc/layouts/wonderswan.xml
+++ b/_inc/layouts/wonderswan.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.35</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.29</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.245 0.488" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.245 0.488" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.48</origin>

--- a/_inc/layouts/wonderswancolor.xml
+++ b/_inc/layouts/wonderswancolor.xml
@@ -13,7 +13,7 @@
 			<maxSize>0.29</maxSize>
 			<maxSize if="${screen.ratio} == '4/3'">0.34</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.238 0.48" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.238 0.48" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '21/9'">0.52 0.5</origin>

--- a/_inc/layouts/x1.xml
+++ b/_inc/layouts/x1.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.32</pos>
 			<maxSize>0.28</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.32" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.32" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.27</origin>

--- a/_inc/layouts/x68000.xml
+++ b/_inc/layouts/x68000.xml
@@ -12,7 +12,7 @@
 			<pos>0.5 0.35</pos>
 			<maxSize>0.25</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.35" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.35" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.29</origin>

--- a/_inc/layouts/xash3d_fwgs.xml
+++ b/_inc/layouts/xash3d_fwgs.xml
@@ -12,7 +12,7 @@
 			<pos>0.4482 0.457</pos>
 			<maxSize>0.27</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.1682 0.457" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.1682 0.457" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.45</origin>

--- a/_inc/layouts/xbla.xml
+++ b/_inc/layouts/xbla.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.49</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.42</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3905</origin>

--- a/_inc/layouts/xbox.xml
+++ b/_inc/layouts/xbox.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.42</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.36</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.375</origin>

--- a/_inc/layouts/xbox360.xml
+++ b/_inc/layouts/xbox360.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.49</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.42</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.22 0.385" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.385" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.3905</origin>

--- a/_inc/layouts/xboxone.xml
+++ b/_inc/layouts/xboxone.xml
@@ -14,7 +14,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.594</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.494</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.219 0.425" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.219 0.425" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -25,7 +25,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.44</origin>

--- a/_inc/layouts/xboxpass.xml
+++ b/_inc/layouts/xboxpass.xml
@@ -12,7 +12,7 @@
 			<path>./../../_inc/anim/xboxpass-fix.png</path>
 			<zIndex>27</zIndex>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<image name="sysbg-video" extra="true">
@@ -26,7 +26,7 @@
 			<size if="${screen.ratio} == '16/10'">0.55 0.6</size>
 			<size if="${screen.ratio} == '21/9'">0.4 0.75</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -35,7 +35,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.49</origin>

--- a/_inc/layouts/xboxseries.xml
+++ b/_inc/layouts/xboxseries.xml
@@ -15,7 +15,7 @@
 			<maxSize if="${screen.ratio} == '4/3'">0.555</maxSize>
 			<maxSize if="${screen.ratio} == '16/10'">0.464</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.258 0.4635" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.258 0.4635" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise169.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.469</origin>

--- a/_inc/layouts/xegs.xml
+++ b/_inc/layouts/xegs.xml
@@ -13,7 +13,7 @@
 			<pos>0.475 0.39</pos>
 			<maxSize>0.26</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.195 0.39" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.195 0.39" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -24,7 +24,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/zaccariapinball.xml
+++ b/_inc/layouts/zaccariapinball.xml
@@ -16,7 +16,7 @@
 			<pos>0.501 0.405</pos>
 			<maxSize>0.245</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.221 0.405" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.221 0.405" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -26,7 +26,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/fpinball.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.395</origin>

--- a/_inc/layouts/zeldac.xml
+++ b/_inc/layouts/zeldac.xml
@@ -12,7 +12,7 @@
 			<pos>0.498 0.48</pos>
 			<maxSize>0.28</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.218 0.48" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.218 0.48" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.4</origin>

--- a/_inc/layouts/zinc.xml
+++ b/_inc/layouts/zinc.xml
@@ -13,7 +13,7 @@
 			<size>0.38 0.15</size>
 			<size if="${screen.ratio} == '21/9'">0.285 0.15</size>
 			<storyboard>
-				<animation property="pos" to="0.22 0.363" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.363" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videoboxarcade" extra="true">
@@ -22,7 +22,7 @@
 			<!-- Loads platform video from addon directory, if available -->
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.15</origin>

--- a/_inc/layouts/zx81.xml
+++ b/_inc/layouts/zx81.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/layouts/zxspectrum.xml
+++ b/_inc/layouts/zxspectrum.xml
@@ -12,7 +12,7 @@
 			<pos>0.49 0.4</pos>
 			<maxSize>0.237</maxSize>
 			<storyboard>
-				<animation property="pos" to="0.208 0.402" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.208 0.402" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<video name="videobox" extra="true">
@@ -23,7 +23,7 @@
 			<path>./../../../ckau-book-addons/_inc/anim/video/${system.theme}.mp4</path>
 			<path>./../../../ckau-book-addons/_inc/anim/video/${synonym}.mp4</path>
 			<default>./../../_inc/anim/video/CRT_Noise.mp4</default>
-			<delay>0</delay>
+			<delay>1</delay>
 			<effect>none</effect>
 			<origin>0.5 0.5</origin>
 			<origin if="${screen.ratio} == '4/3'">0.5 0.35</origin>

--- a/_inc/systemviews/animate.xml
+++ b/_inc/systemviews/animate.xml
@@ -33,7 +33,7 @@
 			<zIndex>30</zIndex>
 			<visible>true</visible>
 			<storyboard>
-				<animation property="pos" to="0.22 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.22 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 <!-- 
@@ -96,9 +96,9 @@
 			<fontSize if="${screen.ratio} == '4/3'">0.045</fontSize>
 			<zIndex>140</zIndex>
 			<storyboard>
-				<animation property="y" from="0.1" begin="3000" duration="500" mode="linear"/>
+				<animation property="y" from="0.1" begin="4000" duration="500" mode="linear"/>
 				<animation property="opacity" to="0" begin="0" duration="0" mode="linear"/>
-				<animation property="opacity" from="0" to="1" begin="3000" duration="500" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" begin="4000" duration="500" mode="EaseIn"/>
 			</storyboard>
 		</text>
 		<text name="TextManufacturer" extra="true">
@@ -112,9 +112,9 @@
 			<autoScrollDelay>3000</autoScrollDelay>
 			<singleLineScroll>true</singleLineScroll>
 			<storyboard>
-				<animation property="x" from="0.6" begin="2500" duration="600" mode="EaseOut"/>
+				<animation property="x" from="0.6" begin="3500" duration="600" mode="EaseOut"/>
 				<animation property="opacity" to="0" begin="0" duration="0" mode="linear"/>
-				<animation property="opacity" from="0" to="1" begin="2500" duration="500" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" begin="3500" duration="500" mode="EaseIn"/>
 			</storyboard>
 		</text>
 		<text name="TextName" extra="true">
@@ -131,9 +131,9 @@
 			<autoScrollDelay>3000</autoScrollDelay>
 			<singleLineScroll>true</singleLineScroll>
 			<storyboard>
-				<animation property="x" from="0.6" begin="2500" duration="600" mode="EaseInOut"/>
+				<animation property="x" from="0.6" begin="3500" duration="600" mode="EaseInOut"/>
 				<animation property="opacity" to="0" begin="0" duration="0" mode="linear"/>
-				<animation property="opacity" from="0" to="1" begin="2500" duration="500" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" begin="3500" duration="500" mode="EaseIn"/>
 			</storyboard>
 		</text>
 		<text name="TextVariant" extra="true">
@@ -151,9 +151,9 @@
 			<autoScrollDelay>3000</autoScrollDelay>
 			<singleLineScroll>true</singleLineScroll>
 			<storyboard>
-				<animation property="x" from="0.6" begin="2500" duration="700" mode="EaseInOut"/>
+				<animation property="x" from="0.6" begin="3500" duration="700" mode="EaseInOut"/>
 				<animation property="opacity" to="0" begin="0" duration="0" mode="linear"/>
-				<animation property="opacity" from="0" to="1" begin="2500" duration="500" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" begin="3500" duration="500" mode="EaseIn"/>
 			</storyboard>
 		</text>
 		<text name="TextDesc" extra="true">
@@ -169,9 +169,9 @@
 			<lineSpacing>1.1</lineSpacing>
 			<zIndex>140</zIndex>
 			<storyboard>
-				<animation property="x" from="0.6" begin="3000" duration="600" mode="EaseInOut"/>
+				<animation property="x" from="0.6" begin="4000" duration="600" mode="EaseInOut"/>
 				<animation property="opacity" to="0" begin="0" duration="0" mode="linear"/>
-				<animation property="opacity" from="0" to="1" begin="3000" duration="600" mode="EaseIn"/>
+				<animation property="opacity" from="0" to="1" begin="4000" duration="600" mode="EaseIn"/>
 			</storyboard>
 		</text>
 

--- a/_inc/systemviews/animatetransparent.xml
+++ b/_inc/systemviews/animatetransparent.xml
@@ -13,7 +13,7 @@
 			<zIndex>90</zIndex>
 			<storyboard>
 				<animation property="pos" to="1.5 0.5" begin="0" duration="0" mode="linear"/>
-				<animation property="pos" to="0.95 0.5" begin="2000" duration="1000" mode="linear"/>
+				<animation property="pos" to="0.95 0.5" begin="3000" duration="1000" mode="linear"/>
 			</storyboard>
 		</image>
 		<text name="info1, info2, info3, info4, info5, info6, info7, info8, info9, info10, info11, info12" extra="static">


### PR DESCRIPTION
Added a 1-second video delay in system view to avoid crashes in Retrobat.

# Video Delay Optimization - Changelog (January 2026)

## Problem Solved
Videos in system views were starting too quickly, causing potential GPU crashes as the graphics card didn't have enough time to load the video.

## Changes Applied

### 1. Video Delay (+1 second)
**Files:** `_inc/layouts/*.xml` (431 files)
- `<delay>0</delay>` → `<delay>1</delay>`
- The delay gives the GPU time to load the video without crashing

### 2. Image Animations (+1000ms)
**Files:** `_inc/layouts/*.xml`
- `sysbg-video`: `begin="2000"` → `begin="3000"`
- `videobox`: `begin="2000"` → `begin="2000"` (stays at 2000 because the 1s video delay effectively brings it to 3000ms)

**Files:** `_inc/systemviews/animate.xml` and `animatetransparent.xml`
- `sysart`: `begin="2000"` → `begin="3000"`

### 3. Text Animations (+1000ms)
**File:** `_inc/systemviews/animate.xml`
- `TextManufacturer`: `begin="2500"` → `begin="3500"`
- `TextName`: `begin="2500"` → `begin="3500"`
- `TextVariant`: `begin="2500"` → `begin="3500"`
- `TextDate`: `begin="3000"` → `begin="4000"`
- `TextDesc`: `begin="3000"` → `begin="4000"`

## Final Timing (from page load)
| Element | Timing |
|---------|--------|
| Video starts loading | 0ms |
| Video starts playing | 1000ms (delay) |
| Images + video movement | 3000ms |
| Manufacturer/Name/Variant texts | 3500ms |
| Date/Desc texts | 4000ms |

## Important Notes
- The `<delay>1</delay>` is ESSENTIAL - never remove it
- Video animation uses `begin="2000"` because it starts after the 1s delay
- Other animations use `begin="3000"` because they start from page load