### PR TITLE
Add synonym for 'imageviewer' theme

### DIFF
--- a/_inc/elements/synonyms.xml
+++ b/_inc/elements/synonyms.xml
@@ -29,5 +29,6 @@
 		<synonym if="${system.theme} == 'zc210'">zeldac</synonym>
 		<synonym if="${system.theme} == 'singe2'">actionmax</synonym>
 		<synonym if="${system.theme} == 'quake3'">ioquake3</synonym>
+		<synonym if="${system.theme} == 'imageviewer'">screenshots</synonym>
 	</variables>
 </theme>


### PR DESCRIPTION
In Batocera v43 (devbuild for now), the "image viewer" category has been renamed "screenshots". A synonym for the category ensures that v42 and v43 are consistent on this point.